### PR TITLE
✨ Makes the options getter all generic-like

### DIFF
--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -48,25 +48,21 @@ class Tooltip {
 	 * declaratively, this method is used to extract the data attributes from
 	 * the DOM.
 	 * @param {HTMLElement} tooltipEl - The tooltip element in the DOM (Required)
-	 * @todo - refactor this out to smartly iterate over data attributes
 	*/
 	static getOptions(tooltipEl) {
-		let opts = {};
-		if (tooltipEl.hasAttribute('data-o-tooltip-position')) {
-			opts.position = tooltipEl.getAttribute('data-o-tooltip-position');
-		}
-		if (tooltipEl.hasAttribute('data-o-tooltip-target')) {
-			opts.target = tooltipEl.getAttribute('data-o-tooltip-target');
-		}
+		const dataset = tooltipEl.dataset;
+		return Object.keys(dataset).reduce((col, key) => { // Phantom doesn't like Object.entries :sob:
+			if (key === 'oComponent') return col; // Bail on data-o-component
+			const shortKey = key.replace(/^oTooltip(\w)(\w+)$/, (m, m1, m2) => m1.toLowerCase() + m2);
 
-		if (tooltipEl.hasAttribute('data-o-tooltip-show-on-construction')){
-			opts.showOnConstruction = (tooltipEl.getAttribute('data-o-tooltip-show-on-construction') === 'true');
-		}
+			try {
+				col[shortKey] = JSON.parse(dataset[key].replace(/\'/g, '"'));
+			} catch (e) {
+				col[shortKey] = dataset[key];
+			}
 
-		if (tooltipEl.hasAttribute('data-o-tooltip-z-index')){
-			opts.zIndex = tooltipEl.getAttribute('data-o-tooltip-z-index');
-		}
-		return opts;
+			return col;
+		}, {});
 	};
 
 	/**

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -143,7 +143,7 @@ describe("Tooltip", () => {
 			el.setAttribute('data-o-tooltip-z-index', "20");
 
 			const options = Tooltip.getOptions(el);
-			proclaim.strictEqual(options.zIndex, "20");
+			proclaim.strictEqual(options.zIndex, 20);
 		});
 	});
 


### PR DESCRIPTION
Adapted from https://github.com/Financial-Times/o-overlay/blob/master/src/js/utils.js#L34

I didn't bother with recursive nested object logic because I haven't seen any examples where such syntax is used within Origami. Feel free to provide one and I'll amend the PR.