### PR TITLE
Fix render bug where the tooltip disappears on hov

### DIFF
--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -262,7 +262,7 @@ class Tooltip {
 		this.tooltipEl.addEventListener('transitionend', () => {
 			// Check this is still false and that the tooltip hasn't reappeared
 			// in the transition period
-			if(this.visible == false) {
+			if(this.visible === false) {
 				this.tooltipEl.style.display = 'none';
 			}
 		}, {once: true});

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -260,7 +260,11 @@ class Tooltip {
 
 		// Set `display: none` after animation & remove listener
 		this.tooltipEl.addEventListener('transitionend', () => {
-			this.tooltipEl.style.display = 'none';
+			// Check this is still false and that the tooltip hasn't reappeared
+			// in the transition period
+			if(this.visible == false) {
+				this.tooltipEl.style.display = 'none';
+			}
 		}, {once: true});
 
 		if (this.opts.showOnClick) {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -262,7 +262,7 @@ class Tooltip {
 		this.tooltipEl.addEventListener('transitionend', () => {
 			// Check this is still false and that the tooltip hasn't reappeared
 			// in the transition period
-			if(this.visible === false) {
+			if (this.visible === false) {
 				this.tooltipEl.style.display = 'none';
 			}
 		}, {once: true});


### PR DESCRIPTION
Because the transition takes about a second, it is possible to get the
tooltip to never slide in and then disappear by quickly moving the
mouse in and out of the target before the tooltip finishes animating

This commit fixes this bug by adding a check to make sure the tooltip
is still not visible when display:none is applied to the tooltip.

Fixes #23 