### PR TITLE
Add event names which conform with Origami convention

### DIFF
--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -169,7 +169,12 @@ class Tooltip {
 		// Delegate pattern
 		this.delegates.doc.root(document.body);
 		this.delegates.tooltip.root(this.tooltipEl);
+
+		// VVV Deprecated - Remove this in V3. VVV
+		console.warn('The event o.tooltipShown is deprecated and is replaced by the event oTooltip.show');
 		this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipShown'));
+		// ^^^ Deprecated - Remove this in V3. ^^^
+
 		this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.show'));
 
 		// Set up all the ways to close the tooltip
@@ -248,7 +253,12 @@ class Tooltip {
 	 * Close the tooltip. (Visually hide it and remove event listeners)
 	*/
 	close() {
+
+		// VVV Deprecated - Remove this in V3. VVV
+		console.warn('The event o.tooltipClosed is deprecated and is replaced by the event oTooltip.close');
 		this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipClosed'));
+		// ^^^ Deprecated - Remove this in V3. ^^^
+
 		this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.close'));
 		this.delegates.doc.destroy();
 		this.delegates.tooltip.destroy();

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -169,6 +169,7 @@ class Tooltip {
 		// Delegate pattern
 		this.delegates.doc.root(document.body);
 		this.delegates.tooltip.root(this.tooltipEl);
+		this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipShown'));
 		this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.show'));
 
 		// Set up all the ways to close the tooltip
@@ -247,6 +248,7 @@ class Tooltip {
 	 * Close the tooltip. (Visually hide it and remove event listeners)
 	*/
 	close() {
+		this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipClosed'));
 		this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.close'));
 		this.delegates.doc.destroy();
 		this.delegates.tooltip.destroy();

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -169,7 +169,7 @@ class Tooltip {
 		// Delegate pattern
 		this.delegates.doc.root(document.body);
 		this.delegates.tooltip.root(this.tooltipEl);
-		this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipShown'));
+		this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.show'));
 
 		// Set up all the ways to close the tooltip
 		this.closeHandler = this.close.bind(this);
@@ -247,7 +247,7 @@ class Tooltip {
 	 * Close the tooltip. (Visually hide it and remove event listeners)
 	*/
 	close() {
-		this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipClosed'));
+		this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.close'));
 		this.delegates.doc.destroy();
 		this.delegates.tooltip.destroy();
 

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -424,20 +424,36 @@ describe("Tooltip", () => {
 			proclaim.isTrue(drawTooltipStub.called);
 		});
 
-		it('emits o.tooltipShown event', function(done) {
+		it('emits o.tooltipShown event', function (done) {
 			this.timeout(1000);
+
+			const timer = setTimeout(() => {
+				proclaim.fail('o.tooltipShown event to fire', 'o.tooltipShown event did not fire');
+			}, 500);
+
 			const tooltipEl = document.getElementById('tooltip-demo');
 			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
-			testTooltip.delegates.tooltip.on('o.tooltipShown', () => done());
+			testTooltip.delegates.tooltip.on('o.tooltipShown', () => {
+				clearTimeout(timer);
+				done();
+			});
 
 			testTooltip.show();
 		});
 
 		it('emits oTooltip.show event', function(done) {
 			this.timeout(1000);
+
+			const timer = setTimeout(() => {
+				proclaim.fail('oTooltip.show event to fire', 'oTooltip.show event did not fire');
+			}, 500);
+
 			const tooltipEl = document.getElementById('tooltip-demo');
 			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
-			testTooltip.delegates.tooltip.on('oTooltip.show', () => done());
+			testTooltip.delegates.tooltip.on('oTooltip.show', () => {
+				clearTimeout(timer);
+				done();
+			});
 
 			testTooltip.show();
 		});
@@ -1293,9 +1309,17 @@ describe("Tooltip", () => {
 
 		it('emits o.tooltipClosed event', function(done) {
 			this.timeout(1000);
+
+			const timer = setTimeout(() => {
+				proclaim.fail('o.tooltipClosed event to fire', 'o.tooltipClosed event did not fire');
+			}, 500);
+
 			const tooltipEl = document.getElementById('tooltip-demo');
 			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
-			testTooltip.delegates.tooltip.on('o.tooltipClosed', () => done());
+			testTooltip.delegates.tooltip.on('o.tooltipClosed', () => {
+				clearTimeout(timer);
+				done();
+			});
 
 			testTooltip.show();
 			testTooltip.close();
@@ -1303,9 +1327,17 @@ describe("Tooltip", () => {
 
 		it('emits oTooltip.close event', function(done) {
 			this.timeout(1000);
+
+			const timer = setTimeout(() => {
+				proclaim.fail('oTooltip.close event to fire', 'oTooltip.close event did not fire');
+			}, 500);
+
 			const tooltipEl = document.getElementById('tooltip-demo');
 			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
-			testTooltip.delegates.tooltip.on('oTooltip.close', () => done());
+			testTooltip.delegates.tooltip.on('oTooltip.close', () => {
+				clearTimeout(timer);
+				done();
+			});
 
 			testTooltip.show();
 			testTooltip.close();

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -432,6 +432,15 @@ describe("Tooltip", () => {
 
 			testTooltip.show();
 		});
+
+		it('emits oTooltip.show event', function(done) {
+			this.timeout(1000);
+			const tooltipEl = document.getElementById('tooltip-demo');
+			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
+			testTooltip.delegates.tooltip.on('oTooltip.show', () => done());
+
+			testTooltip.show();
+		});
 	});
 
 	describe("drawTooltip", () => {
@@ -1287,6 +1296,16 @@ describe("Tooltip", () => {
 			const tooltipEl = document.getElementById('tooltip-demo');
 			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
 			testTooltip.delegates.tooltip.on('o.tooltipClosed', () => done());
+
+			testTooltip.show();
+			testTooltip.close();
+		});
+
+		it('emits oTooltip.close event', function(done) {
+			this.timeout(1000);
+			const tooltipEl = document.getElementById('tooltip-demo');
+			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
+			testTooltip.delegates.tooltip.on('oTooltip.close', () => done());
 
 			testTooltip.show();
 			testTooltip.close();


### PR DESCRIPTION
Origami components have a convention to use `componentName.action` as the event name.

Examples:
https://github.com/Financial-Times/o-expander/blob/c999c88d411103de554b5d5ab73a37b3b6382a4f/main.js#L197-L199
https://github.com/Financial-Times/o-viewport/blob/a07afe45e805b14304016e51994c45fb68182755/src/utils.js#L13

Link to Slack discussion on this -- https://financialtimes.slack.com/archives/C02FU5ARJ/p1503581997000226