### PR TITLE
Position tooltips absolutely and append to the body

### DIFF
--- a/demos/src/absolute-position-test.mustache
+++ b/demos/src/absolute-position-test.mustache
@@ -1,0 +1,21 @@
+
+<div style="position: relative; top: 100px; left: 100px; width: 400px;">
+
+	<div style="position: absolute; top: 200px; right: 100px;">
+
+		<button class='o-buttons o-buttons--big demo-tooltip-target' id="demo-tooltip-target">
+			Share
+		</button>
+
+	</div>
+
+</div>
+
+<div data-o-component="o-tooltip"
+data-o-tooltip-position="below"
+data-o-tooltip-target="demo-tooltip-target"
+data-o-tooltip-show-on-click="true">
+	<div class='o-tooltip-content'>
+		Share this article via email
+	</div>
+</div>

--- a/demos/src/absolute-position-test.mustache
+++ b/demos/src/absolute-position-test.mustache
@@ -1,21 +1,130 @@
 
-<div style="position: relative; top: 100px; left: 100px; width: 400px;">
+<div class="demo-positioning-container">
 
-	<div style="position: absolute; top: 200px; right: 100px;">
+	<button class="o-buttons o-buttons--big position-absolute position-top position-left" id="demo-tooltip-target-1">
+		Top Left
+	</button>
 
-		<button class='o-buttons o-buttons--big demo-tooltip-target' id="demo-tooltip-target">
-			Share
-		</button>
+	<button class="o-buttons o-buttons--big position-absolute position-top position-center" id="demo-tooltip-target-2">
+		Top Center
+	</button>
 
-	</div>
+	<button class="o-buttons o-buttons--big position-absolute position-top position-right" id="demo-tooltip-target-3">
+		Top Right
+	</button>
+
+	<button class="o-buttons o-buttons--big position-absolute position-middle position-left" id="demo-tooltip-target-4">
+		Middle Left
+	</button>
+
+	<button class="o-buttons o-buttons--big position-absolute position-middle position-center" id="demo-tooltip-target-5">
+		Middle Center
+	</button>
+
+	<button class="o-buttons o-buttons--big position-absolute position-middle position-right" id="demo-tooltip-target-6">
+		Middle Right
+	</button>
+
+	<button class="o-buttons o-buttons--big position-absolute position-bottom position-left" id="demo-tooltip-target-7">
+		Bottom Left
+	</button>
+
+	<button class="o-buttons o-buttons--big position-absolute position-bottom position-center" id="demo-tooltip-target-8">
+		Bottom Center
+	</button>
+
+	<button class="o-buttons o-buttons--big position-absolute position-bottom position-right" id="demo-tooltip-target-9">
+		Bottom Right
+	</button>
 
 </div>
 
+<div class="demo-positioning-container">
+	<div class="demo-positioning-explainer">
+		Keep scrolling&hellip;
+	</div>
+</div>
+
+<div class="demo-positioning-container">
+	<div class="demo-positioning-explainer">
+		Keep scrolling&hellip;
+	</div>
+</div>
+
+<div class="demo-positioning-container">
+	<div class="demo-positioning-explainer">
+		OK you can stop scrolling
+	</div>
+</div>
+
 <div data-o-component="o-tooltip"
-data-o-tooltip-position="below"
-data-o-tooltip-target="demo-tooltip-target"
-data-o-tooltip-show-on-click="true">
-	<div class='o-tooltip-content'>
-		Share this article via email
+	data-o-tooltip-target="demo-tooltip-target-1"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-2"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-3"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-4"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-5"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-6"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-7"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-8"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-9"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
 	</div>
 </div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -42,3 +42,54 @@ body {
 	position: fixed;
 	top: 0;
 }
+
+
+
+.demo-positioning-container {
+	width: auto;
+	min-height: 300px;
+	height: 100vh;
+	position: relative;
+}
+
+.demo-positioning-explainer {
+	position: absolute;
+	display: block;
+	width: 100%;
+	margin: 0 auto;
+	padding-top: 100px;
+	text-align: center;
+}
+
+.position-relative {
+	position: relative;
+}
+.position-absolute {
+	position: absolute;
+	z-index: 100;
+}
+.position-fixed {
+	position: fixed;
+	z-index: 100;
+}
+.position-top {
+	top: 20px;
+}
+.position-bottom {
+	bottom: 20px;
+}
+.position-left {
+	left: 20px;
+}
+.position-right {
+	right: 20px;
+}
+.position-center {
+	left: 50%;
+	margin-left: -100px;
+	width: 200px;
+}
+.position-middle {
+	top: 50%;
+	margin-top: -20px;
+}

--- a/demos/src/fixed-position-test.mustache
+++ b/demos/src/fixed-position-test.mustache
@@ -1,0 +1,130 @@
+
+<div class="demo-positioning-container">
+
+	<button class="o-buttons o-buttons--big position-fixed position-top position-left" id="demo-tooltip-target-1">
+		Top Left
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-top position-center" id="demo-tooltip-target-2">
+		Top Center
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-top position-right" id="demo-tooltip-target-3">
+		Top Right
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-middle position-left" id="demo-tooltip-target-4">
+		Middle Left
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-middle position-center" id="demo-tooltip-target-5">
+		Middle Center
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-middle position-right" id="demo-tooltip-target-6">
+		Middle Right
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-bottom position-left" id="demo-tooltip-target-7">
+		Bottom Left
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-bottom position-center" id="demo-tooltip-target-8">
+		Bottom Center
+	</button>
+
+	<button class="o-buttons o-buttons--big position-fixed position-bottom position-right" id="demo-tooltip-target-9">
+		Bottom Right
+	</button>
+
+</div>
+
+<div class="demo-positioning-container">
+	<div class="demo-positioning-explainer">
+		Keep scrolling&hellip;
+	</div>
+</div>
+
+<div class="demo-positioning-container">
+	<div class="demo-positioning-explainer">
+		Keep scrolling&hellip;
+	</div>
+</div>
+
+<div class="demo-positioning-container">
+	<div class="demo-positioning-explainer">
+		OK you can stop scrolling
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-1"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-2"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-3"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-4"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-5"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-6"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-7"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-8"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>
+
+<div data-o-component="o-tooltip"
+	data-o-tooltip-target="demo-tooltip-target-9"
+	data-o-tooltip-show-on-click="true">
+	<div class="o-tooltip-content">
+		Example tooltip
+	</div>
+</div>

--- a/origami.json
+++ b/origami.json
@@ -68,6 +68,12 @@
 				"description": "absolute parent position testcase"
 			},
 			{
+				"name": "fixed-position-test",
+				"template": "demos/src/fixed-position-test.mustache",
+				"hidden": true,
+				"description": "fixed position testcase"
+			},
+			{
 				"name": "pa11y",
 				"template": "demos/src/pa11y.mustache",
 				"hidden": true,

--- a/origami.json
+++ b/origami.json
@@ -62,6 +62,12 @@
 				"description": "relative parent position testcase"
 			},
 			{
+				"name": "absolute-position-test",
+				"template": "demos/src/absolute-position-test.mustache",
+				"hidden": true,
+				"description": "absolute parent position testcase"
+			},
+			{
 				"name": "pa11y",
 				"template": "demos/src/pa11y.mustache",
 				"hidden": true,

--- a/src/js/target.js
+++ b/src/js/target.js
@@ -3,7 +3,7 @@ class Target {
 		this.targetEl = targetEl;
 
 		// @deprecated This is not used anywhere in the codebase, seems like we don't need it
-        this.rectObject = targetEl.getBoundingClientRect();
+        this.rectObject = (targetEl ? targetEl.getBoundingClientRect() : {});
     }
 
     // @deprecated This is not used anywhere in the codebase, seems like we don't need it
@@ -22,7 +22,15 @@ class Target {
 	// @deprecated ^^^
 
 	get left() {
-		return this.targetEl.getBoundingClientRect().left;
+		const left = (this.targetEl ? this.targetEl.getBoundingClientRect().left : 0);
+
+		// If the target has a fixed parent, we just return the bounding client rect
+		// left value, as this is correct. Otherwise we have to add the current scroll
+		// position to make absolute positioning work correctly
+		if (this.hasFixedParent()) {
+			return left;
+		}
+		return left + (document.body.scrollLeft || document.documentElement.scrollLeft);
 	}
 
 	get right() {
@@ -30,12 +38,12 @@ class Target {
 	}
 
 	get top() {
-		const top = this.targetEl.getBoundingClientRect().top;
+		const top = (this.targetEl ? this.targetEl.getBoundingClientRect().top : 0);
 
 		// If the target has a fixed parent, we just return the bounding client rect
 		// top value, as this is correct. Otherwise we have to add the current scroll
 		// position to make absolute positioning work correctly
-		if (this.hasFixedParent) {
+		if (this.hasFixedParent()) {
 			return top;
 		}
 		return top + (document.body.scrollTop || document.documentElement.scrollTop);
@@ -46,11 +54,11 @@ class Target {
 	}
 
 	get width() {
-		return this.targetEl.getBoundingClientRect().width;
+		return (this.targetEl ? this.targetEl.getBoundingClientRect().width : 0);
 	}
 
 	get height() {
-		return this.targetEl.getBoundingClientRect().height;
+		return (this.targetEl ? this.targetEl.getBoundingClientRect().height : 0);
 	}
 
 	get centrePoint(){
@@ -58,7 +66,7 @@ class Target {
 	}
 
 	// Work out whether the target has a fixed parent
-	get hasFixedParent() {
+	hasFixedParent() {
 		let currentNode = this.targetEl;
 		while (currentNode.parentNode) {
 			if (window.getComputedStyle(currentNode).position === 'fixed') {

--- a/src/js/target.js
+++ b/src/js/target.js
@@ -30,7 +30,15 @@ class Target {
 	}
 
 	get top() {
-		return this.targetEl.getBoundingClientRect().top + (document.body.scrollTop || document.documentElement.scrollTop);
+		const top = this.targetEl.getBoundingClientRect().top;
+
+		// If the target has a fixed parent, we just return the bounding client rect
+		// top value, as this is correct. Otherwise we have to add the current scroll
+		// position to make absolute positioning work correctly
+		if (this.hasFixedParent) {
+			return top;
+		}
+		return top + (document.body.scrollTop || document.documentElement.scrollTop);
 	}
 
 	get bottom() {
@@ -47,6 +55,18 @@ class Target {
 
 	get centrePoint(){
 		return { x: this.left + (this.width/2), y: this.top + (this.height/2)};
+	}
+
+	// Work out whether the target has a fixed parent
+	get hasFixedParent() {
+		let currentNode = this.targetEl;
+		while (currentNode.parentNode) {
+			if (window.getComputedStyle(currentNode).position === 'fixed') {
+				return true;
+			}
+			currentNode = currentNode.parentNode;
+		}
+		return false;
 	}
 }
 

--- a/src/js/target.js
+++ b/src/js/target.js
@@ -14,12 +14,15 @@ class Target {
     }
     // @deprecated ^^^
 
+	// @deprecated This is not used anywhere in the codebase, seems like we don't need it
 	get offsetTop() {
+		console.warn('The `offsetTop` property is deprecated and will be removed in the next major version of o-tooltip');
 		return this.targetEl.offsetTop;
 	}
+	// @deprecated ^^^
 
 	get left() {
-		return this.targetEl.getBoundingClientRect().left - (this.targetEl.offsetParent && this.targetEl.offsetParent.getBoundingClientRect().left);
+		return this.targetEl.getBoundingClientRect().left;
 	}
 
 	get right() {
@@ -27,7 +30,7 @@ class Target {
 	}
 
 	get top() {
-		return this.targetEl.getBoundingClientRect().top - (this.targetEl.offsetParent && this.targetEl.offsetParent.getBoundingClientRect().top);
+		return this.targetEl.getBoundingClientRect().top + (document.body.scrollTop || document.documentElement.scrollTop);
 	}
 
 	get bottom() {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -489,8 +489,13 @@ class Tooltip {
 	};
 
 	_drawTooltip(rect) {
-		this.tooltipEl.style.top = rect.top + 'px';
 		this.tooltipEl.style.left = rect.left + 'px';
+		this.tooltipEl.style.top = rect.top + 'px';
+		if (this.target.hasFixedParent) {
+			this.tooltipEl.style.position = 'fixed';
+		} else {
+			this.tooltipEl.style.position = 'absolute';
+		}
 	};
 
 	// the bounds here are the size of the client window to catch all cases

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -133,14 +133,9 @@ class Tooltip {
 	 * Render the tooltip. Adds markup and attributes to this.tooltipEl in the DOM
 	*/
 	render() {
-		// make sure the tooltip is the next sibling of the target and (in the case of generated tooltip el)
-		// is attached to the DOM
-		if (this.targetNode && this.targetNode.nextSibling !== this.tooltipEl) {
-			if (this.targetNode.nextSibling) {
-				this.targetNode.parentNode.insertBefore(this.tooltipEl, this.targetNode.nextSibling);
-			} else {
-				this.targetNode.parentNode.appendChild(this.tooltipEl);
-			}
+		// make sure the tooltip is in the body
+		if (this.tooltipEl.parentNode !== document.body) {
+			document.body.appendChild(this.tooltipEl);
 		}
 
 		this.tooltipEl.setAttribute('role', 'tooltip');

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -491,7 +491,7 @@ class Tooltip {
 	_drawTooltip(rect) {
 		this.tooltipEl.style.left = rect.left + 'px';
 		this.tooltipEl.style.top = rect.top + 'px';
-		if (this.target.hasFixedParent) {
+		if (this.target && this.target.hasFixedParent()) {
 			this.tooltipEl.style.position = 'fixed';
 		} else {
 			this.tooltipEl.style.position = 'absolute';

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -489,8 +489,8 @@ class Tooltip {
 	};
 
 	_drawTooltip(rect) {
-		this.tooltipEl.style.left = rect.left + 'px';
 		this.tooltipEl.style.top = rect.top + 'px';
+		this.tooltipEl.style.left = rect.left + 'px';
 		if (this.target && this.target.hasFixedParent()) {
 			this.tooltipEl.style.position = 'fixed';
 		} else {

--- a/test/Target.test.js
+++ b/test/Target.test.js
@@ -20,58 +20,73 @@ describe('Target', () => {
         targetEl = undefined;
     });
 
-    context('constructor()', () => {
+    describe('constructor()', () => {
         it('Should set targetEl and its boundingClientRectangle', () => {
             proclaim.deepEqual(target.targetEl, targetEl);
         });
     });
 
-    context('get left()', () => {
+    describe('get left()', () => {
         it('should return the left edge of the target', () => {
-            const leftEdge = targetEl.getBoundingClientRect().left - (targetEl.offsetParent && targetEl.offsetParent.getBoundingClientRect().left);
+            const leftEdge = targetEl.getBoundingClientRect().left;
             proclaim.equal(target.left, leftEdge);
         });
     });
 
-    context('get right()', () => {
+    describe('get right()', () => {
        it('should return the right edge of the target', () => {
            const rightEdge = target.width + target.left;
            proclaim.equal(target.right, rightEdge);
        });
     });
 
-    context('get top()', () => {
+    describe('get top()', () => {
         it('should return the top edge of the target', () => {
-            const topEdge = targetEl.getBoundingClientRect().top - (targetEl.offsetParent && targetEl.offsetParent.getBoundingClientRect().top);
+            const topEdge = targetEl.getBoundingClientRect().top;
             proclaim.equal(target.top, topEdge);
         });
     });
 
-    context('get bottom()', () => {
+    describe('get bottom()', () => {
         it('should return the bottom edge of the target', () => {
             const bottomEdge = target.top + target.height;
             proclaim.equal(target.bottom, bottomEdge);
         });
     });
 
-    context('get width()', () => {
+    describe('get width()', () => {
         it('should return the width of the target', () => {
             proclaim.equal(target.width, targetEl.getBoundingClientRect().width);
         });
     });
 
-    context('get height()', () => {
+    describe('get height()', () => {
         it('should return the height of the target', () => {
             proclaim.equal(target.height, targetEl.getBoundingClientRect().height);
         });
     });
 
-    context('get centrePoint()', () => {
+    describe('get centrePoint()', () => {
         it('should return the centre point of the target', () => {
             proclaim.deepEqual(target.centrePoint, {
                 x: target.left + (target.width/2),
                 y: target.top + (target.height/2)
             });
+        });
+    });
+
+    describe('.hasFixedParent()', () => {
+        it('should return true if the target element has a fixed position', () => {
+            target.targetEl = document.getElementById('positioned-target-by-self');
+            proclaim.isTrue(target.hasFixedParent());
+        });
+        it('should return true if the target element has a parent with a fixed position', () => {
+            target.targetEl = document.getElementById('positioned-target-by-parent');
+            proclaim.isTrue(target.hasFixedParent());
+        });
+        it('should return false if the target element and all parents do not have a fixed position', () => {
+            target.targetEl = document.getElementById('non-positioned-target');
+            proclaim.isFalse(target.hasFixedParent());
         });
     });
 });

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -636,8 +636,8 @@ describe("Tooltip", () => {
 					testTooltip.drawTooltip();
 					proclaim.strictEqual(drawStub.firstCall.args[0], testTooltip.tooltipRect);
 				});
+			});
 		});
-	});
 
 		/* Unhappy path: If the tooltip is slightly offscreen when it is middle aligned, then it aligns
 		the tooltip with an extremity of the target (whichever is results in the tooltip
@@ -987,6 +987,7 @@ describe("Tooltip", () => {
 		});
 
 		afterEach(() => {
+			fixtures.reset();
 			outOfBoundsStub.restore();
 		});
 

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -1175,6 +1175,20 @@ describe("Tooltip", () => {
 			testTooltip._drawTooltip({top: 123, left: 456});
 			proclaim.strictEqual(testTooltip.tooltipEl.style.left, "456px");
 		});
+		it('sets the style.position to "absolute"', () => {
+			testTooltip._drawTooltip({top: 123, left: 456});
+			proclaim.strictEqual(testTooltip.tooltipEl.style.position, 'absolute');
+		});
+		describe('when the target element has a fixed position parent', () => {
+			beforeEach(() => {
+				fixtures.declarativeCode();
+				testTooltip = Tooltip.init('#tooltip-demo-5');
+			});
+			it('sets the style.position to "fixed"', () => {
+				testTooltip._drawTooltip({top: 123, left: 456});
+				proclaim.strictEqual(testTooltip.tooltipEl.style.position, 'fixed');
+			});
+		});
 	});
 
 	describe("_isOutOfBounds", () => {

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -284,27 +284,15 @@ describe("Tooltip", () => {
 			proclaim.isTrue(buttonEl.hasAttribute('role'));
 		});
 
-		it("Inserts adjacent to target element when target has no next sibling", () => {
-			const parent = document.getElementById('demo-tooltip-insertion-test-1');
-			sinon.stub(parent, 'appendChild');
+		it("Inserts in document body if it is not already a child", () => {
+			const appendStub = sinon.stub(document.body, 'appendChild');
 			new Tooltip(stubEl, {
 				target: 'demo-tooltip-insertion-test-1-target',
 				content: 'content'
 			});
-			proclaim.isTrue(parent.appendChild.called);
-			proclaim.isTrue(parent.appendChild.args[0][0].textContent === "content");
-		});
-
-		it("Inserts adjacent to target element when target has no next sibling", () => {
-			const parent = document.getElementById('demo-tooltip-insertion-test-2');
-			sinon.stub(parent, 'insertBefore');
-			new Tooltip(stubEl, {
-				target: 'demo-tooltip-insertion-test-2-target',
-				content: 'content'
-			});
-
-			proclaim.isTrue(parent.insertBefore.called);
-			proclaim.isTrue(parent.insertBefore.args[0][0].textContent === "content");
+			document.body.appendChild.restore();
+			proclaim.isTrue(appendStub.called);
+			proclaim.isTrue(appendStub.args[0][0].textContent === "content");
 		});
 
 	});

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -83,6 +83,19 @@ function declarativeCode () {
 			<div></div>
 		</div>
 
+		<!-- Fixed parent tests -->
+		<div style="position: fixed;">
+			<div>
+				<div id="positioned-target-by-parent"></div>
+				<div id="positioned-target-by-self" style="position: fixed;"></div>
+			</div>
+		</div>
+		<div id="position-static-parent">
+			<div>
+				<div id="non-positioned-target"></div>
+			</div>
+		</div>
+
 	`;
 	insert(html);
 }

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -27,6 +27,7 @@ describe("Tooltip", () => {
 	it("should not autoinitialize when the event is not dispached", () => {
 		const initSpy = sinon.spy(Tooltip, 'init');
 		proclaim.equal(initSpy.called, false);
+		initSpy.restore();
 	});
 
 	describe("should create a new", () => {


### PR DESCRIPTION
**DO NOT MERGE:** this work will be released as a beta before
merging into master.

This fixes an issue where tooltips inside elements that have their
overflow hidden do not display (#28).

@jkerr321: I've added you as a reviewer mostly so you can have a
look over if you want to. I'll be releasing as a beta and working
with you to make sure it works for your use-case