### PR TITLE
Remove focus styles so they can be set globally

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -15,7 +15,7 @@
 			"js": "demos/src/demo.js",
 
 			"documentClasses": "",
-			"dependencies": "o-fonts, o-colors, o-buttons"
+			"dependencies": "o-fonts@^3.0.0,o-colors@^4.0.0,o-buttons@^5.0.0,o-normalise@^1.0.0"
 		},
 		"demos": [
 			{

--- a/src/scss/tooltip.scss
+++ b/src/scss/tooltip.scss
@@ -194,10 +194,4 @@
 	padding: 0;
 	margin: 5px 5px 15px 15px;
 	border: 0;
-
-	&:focus {
-		outline-color: oColorsGetPaletteColor('teal-100');
-		outline-style: solid;
-		outline-width: 2px;
-	}
 }

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -61,7 +61,7 @@ function declarativeCode () {
 			data-o-tooltip-show-on-hover="true">
 				Tooltip content
 		</div>
-		
+
 		<div class='tooltip-target' id="demo-tooltip-target-5" style='position:fixed'>
 				Thing to point the tooltip at.
 		</div>
@@ -72,7 +72,7 @@ function declarativeCode () {
 			data-o-tooltip-show-on-hover="true">
 				Tooltip content
 		</div>
-		 
+
 		<!-- note lack of whitespace is there to make sure there is no next sibling (otherwise text node :-O) -->
 		<div id="demo-tooltip-insertion-test-1"><div class='tooltip-target' id="demo-tooltip-insertion-test-1-target">Thing to point the tooltip at.</div></div>
 
@@ -99,4 +99,4 @@ export {
 	declarativeCode,
 	imperativeCode,
 	reset
- };
+};


### PR DESCRIPTION
Applications should set focus styles globally (we recommend using
o-normalise for FT masterbrand products)
This commit removes the self-set focus style on the close button and
adds o-normalise to the demos dependencies.