### PR TITLE
Tooltip position can respond to viewport changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ As with all Origami components, o-tooltip has a [silent mode](http://origami.ft.
 
 ### Updating from v2 to v3
 
-V3 introduces a new dependency on `o-grid`. `o-grid` enables us to position `o-tooltip` dependent on the current breakpoint. To upgrade your project confirm your version of `o-grid`, if your project has one, is compatible. You may do this by installing V3 of `o-tooltip` and confirming there are no build failures. If your project is not compatible update the version of `o-grid` used in your project. Your current use of `o-grid` may be a direct dependency on the `o-grid` component or a sub-dependency of a different component. There are no other breaking changes in this release.
-
+- V3 introduces a new dependency on `o-grid`. `o-grid` enables us to position `o-tooltip` dependent on the current breakpoint. To upgrade your project confirm your version of `o-grid`, if your project has one, is compatible. You may do this by installing V3 of `o-tooltip` and confirming there are no build failures. If your project is not compatible update the version of `o-grid` used in your project. Your current use of `o-grid` may be a direct dependency on the `o-grid` component or a sub-dependency of a different component.
+- The deprecated events `o.tooltipShown` and `o.tooltipClosed` are no longer fired. Use `oTooltip.show` and `oTooltip.close` instead.
+- The deprecated `rectObject` property and `getEdge` method of the `Target` object no longer exist.
 
 ### Updating from v1 to v2
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This HTML is an example of the imperative alternative:
 
 Attributes can be set declaratively, or passed in on instantiation in an options object. A full list of data attributes:
 - `data-o-tooltip-target`: Required. An ID selector for the target of the tooltip (the thing it points to)
-- `data-o-tooltip-position`: Optional. The preferred position of the tooltip relative to the target. Can be one of `above`, `below`, `left`, `right`. If there isn't room to render the tooltip where the option passed in would render it, this value is flipped (above becomes below, left becomes right). Defaults to below.
+- `data-o-tooltip-position`: Optional. The preferred position of the tooltip relative to the target. Can be one of `above`, `below`, `left`, `right`. If there isn't room to render the tooltip where the option passed in would render it, this value is flipped (above becomes below, left becomes right). Defaults to below. You can also specify a different position per viewport width ('default', 'S', 'M', 'L', 'XL') eg data-o-tooltip-position-s="left". The position will fall back to the default in data-o-tooltip-position, otherwise 'below'.
 - `data-o-tooltip-show-on-construction`: Optional. Boolean value. Set to true if you want the tooltip to be rendered immediately after it is constructed. Defaults to false.
 - `data-o-tooltip-show-on-hover`: Optional. Boolean value. Set to true if you want to show and hide the tooltip based on the mouseover and mouseout events (respectively) of the target. Defaults to false.
 - `data-o-tooltip-show-on-click`: Optional. Boolean value. Set to true if you want to show the tooltip upon clicking the target element. Defaults to false.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ As with all Origami components, o-tooltip has a [silent mode](http://origami.ft.
 
 ## Migration Guide
 
+### Updating from v2 to v3
+
+V3 introduces a new dependency on `o-grid`. `o-grid` enables us to position `o-tooltip` dependent on the current breakpoint. To upgrade your project confirm your version of `o-grid`, if your project has one, is compatible. You may do this by installing V3 of `o-tooltip` and confirming there are no build failures. If your project is not compatible update the version of `o-grid` used in your project. Your current use of `o-grid` may be a direct dependency on the `o-grid` component or a sub-dependency of a different component. There are no other breaking changes in this release.
+
+
 ### Updating from v1 to v2
 
 V1 -> V2 introduces the new majors of `o-overlay` and `o-visual-effects`. Updating to this new version will mean updating any other components that you have which are using `o-overlay` or `o-visual-effects`. There are no other breaking changes in this release.

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "o-normalise": "^1.2.1",
     "o-overlay": "^2.0.0",
     "o-viewport": "^3.1.2",
-    "o-visual-effects": "^2.0.0"
+    "o-visual-effects": "^2.0.0",
+    "o-grid": "^4.3.6"
   }
 }

--- a/demos/src/responsive-positioning.mustache
+++ b/demos/src/responsive-positioning.mustache
@@ -1,0 +1,21 @@
+<div class="o-colors-page-background">
+	<div class='demo-tooltip-container' id="box-tooltip" style="margin-top:200px;margin-left:20%">
+
+		<button class='o-buttons o-buttons--big demo-tooltip-target' id="demo-tooltip-target">
+			Share
+		</button>
+
+		<div data-o-component="o-tooltip"
+		data-o-tooltip-position="above"
+		data-o-tooltip-position-s="right"
+		data-o-tooltip-position-m="below"
+		data-o-tooltip-position-l="left"
+		data-o-tooltip-position-xl="above"
+		data-o-tooltip-target="demo-tooltip-target"
+		data-o-tooltip-show-on-construction="true">
+			<div class='o-tooltip-content'>
+				Spin me right round..
+			</div>
+		</div>
+	</div>
+</div>

--- a/main.scss
+++ b/main.scss
@@ -2,7 +2,12 @@
 @import "o-visual-effects/main";
 @import "src/scss/variables";
 @import "src/scss/tooltip";
+@import "o-grid/main";
 
+@if $o-tooltip-is-silent == false {
+	@include oGridSurfaceCurrentLayout;
+	@include oGridSurfaceLayoutSizes;
+}
 
 @if ($o-tooltip-is-silent == false) {
 	 .o-tooltip {

--- a/origami.json
+++ b/origami.json
@@ -54,6 +54,11 @@
 				"description": "Tooltip declared in js, with no markup"
 			},
 			{
+				"name": "responsive-positioning",
+				"template": "demos/src/responsive-positioning.mustache",
+				"description": "Responsive positioning"
+			},
+			{
 				"name": "scroll-test",
 				"template": "demos/src/scroll-test.mustache",
 				"hidden": true,

--- a/src/js/target.js
+++ b/src/js/target.js
@@ -1,18 +1,7 @@
 class Target {
 	constructor(targetEl) {
 		this.targetEl = targetEl;
-
-		// @deprecated This is not used anywhere in the codebase, seems like we don't need it
-		this.rectObject = targetEl.getBoundingClientRect();
 	}
-
-	// @deprecated This is not used anywhere in the codebase, seems like we don't need it
-	getEdge(edge){
-		console.warn('The `getEdge` method is depracated and will be removed in the next major version of o-tooltip');
-		const edges = {"top": this.top, "bottom": this.bottom, "right": this.right, "left": this.left};
-		return edges[edge];
-	}
-	// @deprecated ^^^
 
 	get offsetTop() {
 		return this.targetEl.offsetTop;

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -1,9 +1,14 @@
 import Delegate from 'ftdomdelegate';
 import Viewport from 'o-viewport';
+import oGrid from 'o-grid';
 
 import Target from './target';
 
 class Tooltip {
+
+	static _getCurrentLayout() {
+		return oGrid.getCurrentLayout();
+	}
 
 	/**
 	 * Represents a tooltip.
@@ -29,7 +34,7 @@ class Tooltip {
 
 		this.targetNode = document.getElementById(this.opts.target);
 		this.target = new Tooltip.Target(this.targetNode);
-		this.tooltipPosition = this.opts.position;
+		this.tooltipPosition = this._getTooltipPosition();
 		this.tooltipAlignment = null;
 		this.visible = false;
 
@@ -324,6 +329,7 @@ class Tooltip {
 
 		// (re) set the arrow alignment to middle
 		this.tooltipAlignment = 'middle';
+		this.tooltipPosition = this._getTooltipPosition();
 
 		// First pass at positioning the tooltip...
 		this.calculateTooltipRect(this.tooltipPosition);
@@ -453,6 +459,23 @@ class Tooltip {
 		rect.bottom = rect.top + height;
 
 		this.tooltipRect = rect;
+	}
+
+	_getTooltipPosition() {
+		const { position, positionS, positionM, positionL, positionXl } = this.opts;
+		const currentBreakpoint = Tooltip._getCurrentLayout();
+		switch (currentBreakpoint) {
+			case 'S':
+				return positionS || position;
+			case 'M':
+				return positionM || positionS || position;
+			case 'L':
+				return positionL || positionM || positionS || position;
+			case 'XL':
+				return positionXl || positionL || positionM || positionS || position;
+			default:
+				return position;
+		}
 	}
 
 	_getScrollPosition() { // eslint-disable-line class-methods-use-this

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -174,11 +174,6 @@ class Tooltip {
 		this.delegates.doc.root(document.body);
 		this.delegates.tooltip.root(this.tooltipEl);
 
-		// VVV Deprecated - Remove this in V3. VVV
-		console.warn('The event o.tooltipShown is deprecated and is replaced by the event oTooltip.show');
-		this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipShown'));
-		// ^^^ Deprecated - Remove this in V3. ^^^
-
 		this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.show'));
 
 		// Set up all the ways to close the tooltip
@@ -259,11 +254,6 @@ class Tooltip {
 	close(event, target, fireCloseEvent = true) {
 
 		if(fireCloseEvent) {
-			// VVV Deprecated - Remove this in V3. VVV
-			console.warn('The event o.tooltipClosed is deprecated and is replaced by the event oTooltip.close');
-			this.tooltipEl.dispatchEvent(new CustomEvent('o.tooltipClosed'));
-			// ^^^ Deprecated - Remove this in V3. ^^^
-
 			this.tooltipEl.dispatchEvent(new CustomEvent('oTooltip.close'));
 		}
 

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -657,6 +657,7 @@ describe("Tooltip", () => {
 			let edgeStubValue;
 			let getLeftStub;
 			let getTopStub;
+			let getTooltipPositionStub;
 
 			beforeEach(() => {
 				testTooltip.tooltipRect = {top: 1, bottom: 2, left: 3, right: 4}; // we don't actually read these values
@@ -668,11 +669,13 @@ describe("Tooltip", () => {
 			afterEach(() => {
 				getTopStub.restore();
 				getLeftStub.restore();
+				getTooltipPositionStub.restore();
 			});
 
 			describe("when the tootip is positioned above", ()=> {
+
 				beforeEach(() => {
-					testTooltip.tooltipPosition = "above";
+					getTooltipPositionStub = sinon.stub(Tooltip.prototype, '_getTooltipPosition').returns("above");
 					resetPositionStub.withArgs(testTooltip.tooltipRect.top, 'y').returns([true, 'above']);
 				});
 
@@ -714,7 +717,7 @@ describe("Tooltip", () => {
 
 			describe("when the tootip is positioned below", ()=> {
 				beforeEach(() => {
-					testTooltip.tooltipPosition = "below";
+					getTooltipPositionStub = sinon.stub(Tooltip.prototype, '_getTooltipPosition').returns("below");
 					resetPositionStub.withArgs(testTooltip.tooltipRect.bottom, 'y').returns([true, 'below']);
 				});
 
@@ -756,7 +759,7 @@ describe("Tooltip", () => {
 
 			describe("when the tootip is positioned left", ()=> {
 				beforeEach(() => {
-					testTooltip.tooltipPosition = "left";
+					getTooltipPositionStub = sinon.stub(Tooltip.prototype, '_getTooltipPosition').returns("left");
 					resetPositionStub.withArgs(testTooltip.tooltipRect.left, 'x').returns([true, 'left']);
 				});
 
@@ -798,7 +801,7 @@ describe("Tooltip", () => {
 
 			describe("when the tootip is positioned right", ()=> {
 				beforeEach(() => {
-					testTooltip.tooltipPosition = "right";
+					getTooltipPositionStub = sinon.stub(Tooltip.prototype, '_getTooltipPosition').returns("right");
 					resetPositionStub.withArgs(testTooltip.tooltipRect.right, 'x').returns([true, 'right']);
 				});
 
@@ -1019,6 +1022,93 @@ describe("Tooltip", () => {
 		});
 	});
 
+	describe("_getTooltipPosition", () => {
+		let checkStub;
+		let getStub;
+		let targetStub;
+		let widthStub;
+		let heightStub;
+		let oGridStub;
+
+		let testTooltip;
+
+		beforeEach(() => {
+			getStub = sinon.stub(Tooltip, 'getOptions');
+			targetStub = sinon.stub(Tooltip, 'Target').returns({left: 0, right: 7, centrePoint: {x: 5}});
+			widthStub = sinon.stub(Tooltip.prototype, 'width').returns(100);
+			heightStub = sinon.stub(Tooltip.prototype, 'height').returns(500);
+		});
+
+		afterEach(() => {
+			oGridStub.restore();
+			getStub.restore();
+			checkStub.restore();
+			targetStub.restore();
+			heightStub.restore();
+			widthStub.restore();
+		});
+
+		const tooltipOptions = opts => { checkStub = sinon.stub(Tooltip, 'checkOptions').returns(opts); };
+		const createTooltip = () => new Tooltip(document.createElement('div'));
+		const setViewportWidth = width => { oGridStub = sinon.stub(Tooltip, '_getCurrentLayout').returns(width); };
+
+		it("returns default options position if there are no responsive overrides declared", () => {
+			tooltipOptions({'position': 'above'});
+			testTooltip = createTooltip();
+			setViewportWidth('default');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'above');
+		});
+
+		it("returns small options position if one is declared, and viewport is Small", () => {
+			tooltipOptions({'position': 'above', 'positionS': 'right'});
+			testTooltip = createTooltip();
+			setViewportWidth('S');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'right');
+		});
+
+		it("falls back to  small options position if one is declared, and viewport is Medium", () => {
+			tooltipOptions({'position': 'above', 'positionS': 'right'});
+			testTooltip = createTooltip();
+			setViewportWidth('M');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'right');
+		});
+
+		it("returns medium options position if one is declared, and viewport is Medium", () => {
+			tooltipOptions({'position': 'left', 'positionM': 'below'});
+			testTooltip = createTooltip();
+			setViewportWidth('M');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'below');
+		});
+
+		it("falls back to  medium options position if one is declared, and viewport is Large", () => {
+			tooltipOptions({'position': 'above', 'positionM': 'right'});
+			testTooltip = createTooltip();
+			setViewportWidth('L');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'right');
+		});
+
+		it("returns large options position if one is declared, and viewport is Large", () => {
+			tooltipOptions({'position': 'below', 'positionL': 'left'});
+			testTooltip = createTooltip();
+			setViewportWidth('L');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'left');
+		});
+
+		it("falls back to large options position if one is declared, and viewport is X-Large", () => {
+			tooltipOptions({'position': 'above', 'positionL': 'right'});
+			testTooltip = createTooltip();
+			setViewportWidth('XL');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'right');
+		});
+
+		it("returns x-large options position if one is declared, and viewport is X-Large", () => {
+			tooltipOptions({'position': 'below', 'positionXl': 'top'});
+			testTooltip = createTooltip();
+			setViewportWidth('XL');
+			proclaim.strictEqual(testTooltip._getTooltipPosition(), 'top');
+		});
+	});
+
 	describe("_getLeftFor", () => {
 		let checkStub;
 		let getStub;
@@ -1029,7 +1119,6 @@ describe("Tooltip", () => {
 		let testTooltip;
 
 		beforeEach(() => {
-
 			getStub = sinon.stub(Tooltip, 'getOptions');
 			checkStub = sinon.stub(Tooltip, 'checkOptions').returns({'position': 'above'});
 			targetStub = sinon.stub(Tooltip, 'Target').returns({left: 0, right: 7, centrePoint: {x: 5}});

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -423,23 +423,6 @@ describe("Tooltip", () => {
 			proclaim.isTrue(drawTooltipStub.called);
 		});
 
-		it('emits o.tooltipShown event', function (done) {
-			this.timeout(1000);
-
-			const timer = setTimeout(() => {
-				proclaim.fail('o.tooltipShown event to fire', 'o.tooltipShown event did not fire');
-			}, 500);
-
-			const tooltipEl = document.getElementById('tooltip-demo');
-			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
-			testTooltip.delegates.tooltip.on('o.tooltipShown', () => {
-				clearTimeout(timer);
-				done();
-			});
-
-			testTooltip.show();
-		});
-
 		it('emits oTooltip.show event', function(done) {
 			this.timeout(1000);
 
@@ -1399,24 +1382,6 @@ describe("Tooltip", () => {
 			testTooltip.close();
 		});
 
-		it('emits o.tooltipClosed event', function(done) {
-			this.timeout(1000);
-
-			const timer = setTimeout(() => {
-				proclaim.fail('o.tooltipClosed event to fire', 'o.tooltipClosed event did not fire');
-			}, 500);
-
-			const tooltipEl = document.getElementById('tooltip-demo');
-			const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
-			testTooltip.delegates.tooltip.on('o.tooltipClosed', () => {
-				clearTimeout(timer);
-				done();
-			});
-
-			testTooltip.show();
-			testTooltip.close();
-		});
-
 		it('emits oTooltip.close event', function(done) {
 			this.timeout(1000);
 
@@ -1437,24 +1402,6 @@ describe("Tooltip", () => {
 
 
 		describe('when called with fireCloseEvent=false', function () {
-			it('skips emitting o.tooltipClosed event', function(done) {
-				this.timeout(1000);
-
-				const timer = setTimeout(() => {
-					done();
-				}, 500);
-
-				const tooltipEl = document.getElementById('tooltip-demo');
-				const testTooltip = new Tooltip(tooltipEl, {target: 'demo-tooltip-target'});
-				testTooltip.delegates.tooltip.on('o.tooltipClosed', () => {
-					clearTimeout(timer);
-					proclaim.fail('oTooltip.close event to not fire', 'oTooltip.close event did fire');
-				});
-
-				testTooltip.show();
-				testTooltip.close('', '', false);
-			});
-
 			it('skips emitting oTooltip.close event', function(done) {
 				this.timeout(1000);
 


### PR DESCRIPTION
On viewport resize, plug in to o-grid to find out which breakpoint we're in - default, S, M, L or XL
Then change the tooltip position, if an option for that width exists eg

![image](https://user-images.githubusercontent.com/471250/34000276-b345c218-e0e4-11e7-80a7-9f3e373047d4.png)

At medium viewport width:

![image](https://user-images.githubusercontent.com/471250/34000321-dd10d5ce-e0e4-11e7-92d8-76cfd8e673cb.png)
