### PR TITLE
observe document body height/width

### DIFF
--- a/demos/src/click.mustache
+++ b/demos/src/click.mustache
@@ -6,7 +6,7 @@
 		</button>
 
 		<div data-o-component="o-tooltip"
-		data-o-tooltip-position="below"
+		data-o-tooltip-position="right"
 		data-o-tooltip-target="demo-tooltip-target"
 		data-o-tooltip-show-on-click="true">
 			<div class='o-tooltip-content'>

--- a/demos/src/click.mustache
+++ b/demos/src/click.mustache
@@ -6,7 +6,7 @@
 		</button>
 
 		<div data-o-component="o-tooltip"
-		data-o-tooltip-position="right"
+		data-o-tooltip-position="below"
 		data-o-tooltip-target="demo-tooltip-target"
 		data-o-tooltip-show-on-click="true">
 			<div class='o-tooltip-content'>

--- a/demos/src/scroll-test.mustache
+++ b/demos/src/scroll-test.mustache
@@ -7,7 +7,7 @@
 			</button>
 
 			<div data-o-component="o-tooltip"
-			data-o-tooltip-position="right"
+			data-o-tooltip-position="below"
 			data-o-tooltip-target="demo-tooltip-target"
 			data-o-tooltip-show-on-click="true">
 				<div class='o-tooltip-content'>

--- a/demos/src/scroll-test.mustache
+++ b/demos/src/scroll-test.mustache
@@ -7,7 +7,7 @@
 			</button>
 
 			<div data-o-component="o-tooltip"
-			data-o-tooltip-position="below"
+			data-o-tooltip-position="right"
 			data-o-tooltip-target="demo-tooltip-target"
 			data-o-tooltip-show-on-click="true">
 				<div class='o-tooltip-content'>

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -528,9 +528,9 @@ class Tooltip {
 	static _isOutOfBounds(point, axis, opts) {
 
 		function _checkBounds(element) {
-			if (axis === 'y' && (point > (element.clientHeight + window.scrollY) || point < window.scrollY)) {
+			if (axis === 'y' && (point > (element.clientHeight + window.pageYOffset) || point < window.pageYOffset)) {
 				return true;
-			} else if (axis === 'x' && (point > (element.clientWidth + window.scrollX) || point < window.scrollX)) {
+			} else if (axis === 'x' && (point > (element.clientWidth + window.pageXOffset) || point < window.pageXOffset)) {
 				return true;
 			}
 			return false;

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -358,22 +358,22 @@ class Tooltip {
 			NB once this.tooltipRect.top is set, this.tooltipRect.bottom is no longer correct and should be
 			recalculated before use */
 		if (this.tooltipPosition === 'above' || this.tooltipPosition === 'below') {
-			if (Tooltip._isOutOfBounds(this.tooltipRect.left, 'x')) {
+			if (Tooltip._isOutOfBounds(this.tooltipRect.left, 'x', this.opts)) {
 				this.tooltipRect.left = this._getLeftFor('left');
 				this.tooltipAlignment = 'left';
 			}
-			if (Tooltip._isOutOfBounds(this.tooltipRect.right, 'x')) {
+			if (Tooltip._isOutOfBounds(this.tooltipRect.right, 'x', this.opts)) {
 				this.tooltipRect.left = this._getLeftFor('right');
 				this.tooltipAlignment = 'right';
 			}
 		}
 
 		if (this.tooltipPosition === 'left' || this.tooltipPosition === 'right') {
-			if (Tooltip._isOutOfBounds(this.tooltipRect.top, 'y')) {
+			if (Tooltip._isOutOfBounds(this.tooltipRect.top, 'y', this.opts)) {
 				this.tooltipRect.top = this._getTopFor('top');
 				this.tooltipAlignment = 'top';
 			}
-			if (Tooltip._isOutOfBounds(this.tooltipRect.bottom, 'y')) {
+			if (Tooltip._isOutOfBounds(this.tooltipRect.bottom, 'y', this.opts)) {
 				this.tooltipRect.top = this._getTopFor('bottom');
 				this.tooltipAlignment = 'bottom';
 			}
@@ -403,7 +403,7 @@ class Tooltip {
 	 * if it is, position of the tooltip is set (true) and maintains position
 	*/
 	resetPosition(side, axis) {
-		if (Tooltip._isOutOfBounds(side, axis)) {
+		if (Tooltip._isOutOfBounds(side, axis, this.opts)) {
 			let position = Tooltip._rotateOrientation(this.tooltipPosition);
 			this.calculateTooltipRect(position);
 			return [false, position];
@@ -520,18 +520,27 @@ class Tooltip {
 		this.tooltipEl.style.left = rect.left + 'px';
 	}
 
-	// the bounds here are the size of the client window to catch all cases
-	// where the tooltip may not realistically fit
-	static _isOutOfBounds(point, axis) {
+	/*
+		this measures the boundaries in which the tooltip will realistically fit.
+		if it is shown on construction, the size of the document body will be consulted
+		in all other cases, it will be the size of the viewport.
+	*/
+	static _isOutOfBounds(point, axis, opts) {
+
+		function _checkBounds(element) {
+			if (axis === 'y' && point > element.clientHeight) {
+				return true;
+			} else if (axis === 'x' && point > element.clientWidth) {
+				return true;
+			}
+			return false;
+		}
+
 		if (point < 0) {
 			return true;
 		}
-		if (axis === 'y' && point > document.documentElement.clientHeight && point > document.body.clientHeight) {
-			return true;
-		} else if (axis === 'x' && point > document.documentElement.clientWidth) {
-			return true;
-		}
-		return false;
+
+		return opts.showOnConstruction ? _checkBounds(document.body) : _checkBounds(document.documentElement);
 	}
 
 	static _rotateOrientation(orientation) {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -527,20 +527,25 @@ class Tooltip {
 	*/
 	static _isOutOfBounds(point, axis, opts) {
 
-		function _checkBounds(element) {
-			if (axis === 'y' && (point > (element.clientHeight + window.pageYOffset) || point < window.pageYOffset)) {
-				return true;
-			} else if (axis === 'x' && (point > (element.clientWidth + window.pageXOffset) || point < window.pageXOffset)) {
-				return true;
-			}
-			return false;
-		}
-
 		if (point < 0) {
 			return true;
 		}
 
-		return opts.showOnConstruction ? _checkBounds(document.body) : _checkBounds(document.documentElement);
+		if (opts.showOnConstruction) {
+			if (axis === 'y' && point > document.body.clientHeight) {
+				return true;
+			} else if (axis === 'x' && point > document.body.clientWidth) {
+				return true;
+			}
+		} else {
+			if (axis === 'y' && (point > (document.documentElement.clientHeight + window.pageYOffset) || point < window.pageYOffset)) {
+				return true;
+			} else if (axis === 'x' && (point > (document.documentElement.clientWidth + window.pageXOffset) || point < window.pageXOffset)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	static _rotateOrientation(orientation) {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -526,7 +526,7 @@ class Tooltip {
 		if (point < 0) {
 			return true;
 		}
-		if (axis === 'y' && point > document.documentElement.clientHeight) {
+		if (axis === 'y' && point > document.documentElement.clientHeight && point > document.body.clientHeight) {
 			return true;
 		} else if (axis === 'x' && point > document.documentElement.clientWidth) {
 			return true;

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -528,9 +528,9 @@ class Tooltip {
 	static _isOutOfBounds(point, axis, opts) {
 
 		function _checkBounds(element) {
-			if (axis === 'y' && point > element.clientHeight) {
+			if (axis === 'y' && (point > (element.clientHeight + window.scrollY) || point < window.scrollY)) {
 				return true;
-			} else if (axis === 'x' && point > element.clientWidth) {
+			} else if (axis === 'x' && (point > (element.clientWidth + window.scrollX) || point < window.scrollX)) {
 				return true;
 			}
 			return false;

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -1264,26 +1264,53 @@ describe("Tooltip", () => {
 	});
 
 	describe("_isOutOfBounds", () => {
+
 		it('returns true if the value passed in is less than 0', () => {
 			proclaim.isTrue(Tooltip._isOutOfBounds(-1));
 		});
 
-		it('returns true if the value passed in is greater than document.documentElement.clientHeight and the axis is y', () => {
-			proclaim.isTrue(Tooltip._isOutOfBounds(document.documentElement.clientHeight+1, 'y'));
+		context('with empty opts measures bounds against document.documentElement', () => {
+			const stubOpts = {};
+
+			it('returns true if the value passed in is greater than document.documentElement.clientHeight and the axis is y', () => {
+				proclaim.isTrue(Tooltip._isOutOfBounds(document.documentElement.clientHeight+1, 'y', stubOpts));
+			});
+
+			it('returns true if the value passed in is greater than document.documentElement.clientWidth and the axis is x', () => {
+				proclaim.isTrue(Tooltip._isOutOfBounds(document.documentElement.clientWidth+1, 'x', stubOpts));
+			});
+
+			it('returns false if the value passed in is less than document.documentElement.clientWidth and the axis is x', () => {
+				proclaim.isFalse(Tooltip._isOutOfBounds(document.documentElement.clientWidth-1, 'x', stubOpts));
+			});
+
+			it('returns false if the value passed in is less than document.documentElement.clientHeight and the axis is y', () => {
+				document.body.style.height = "20px";
+
+				proclaim.isFalse(Tooltip._isOutOfBounds(document.documentElement.clientHeight-1, 'y', stubOpts));
+			});
 		});
 
-		it('returns true if the value passed in is greater than document.documentElement.clientWidth and the axis is x', () => {
-			proclaim.isTrue(Tooltip._isOutOfBounds(document.documentElement.clientWidth+1, 'x'));
-		});
+		context('with showOnConstruction opts measures bounds against document.body', () => {
+			const stubOpts = { showOnConstruction: true };
 
-		it('returns false if the value passed in is less than document.documentElement.clientWidth and the axis is x', () => {
-			proclaim.isFalse(Tooltip._isOutOfBounds(document.documentElement.clientWidth-1, 'x'));
-		});
+			it('returns true if the value passed in is greater than document.body.clientHeight and the axis is y', () => {
+				proclaim.isTrue(Tooltip._isOutOfBounds(document.body.clientHeight+1, 'y', stubOpts));
+			});
 
-		it('returns false if the value passed in is less than document.documentElement.clientHeight and the axis is y', () => {
-			document.body.style.height = "20px";
+			it('returns true if the value passed in is greater than document.body.clientWidth and the axis is x', () => {
+				proclaim.isTrue(Tooltip._isOutOfBounds(document.body.clientWidth+1, 'x', stubOpts));
+			});
 
-			proclaim.isFalse(Tooltip._isOutOfBounds(document.documentElement.clientHeight-1, 'y'));
+			it('returns false if the value passed in is less than document.body.clientWidth and the axis is x', () => {
+				proclaim.isFalse(Tooltip._isOutOfBounds(document.body.clientWidth-1, 'x', stubOpts));
+			});
+
+			it('returns false if the value passed in is less than document.body.clientHeight and the axis is y', () => {
+				document.body.style.height = "20px";
+
+				proclaim.isFalse(Tooltip._isOutOfBounds(document.body.clientHeight-1, 'y', stubOpts));
+			});
 		});
 	});
 


### PR DESCRIPTION
Fixes #36 

~I believe what we needed was to take into account that the body may be longer than the viewport, not necessarily wider, and accommodate for that. Thoughts?~

This now checks whether or not the tooltip was shown on construction, and will change the boundaries it calculates with based on that information. 
