### PR TITLE
add o-typography

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "o-overlay": "^2.0.0",
     "o-viewport": "^3.1.2",
     "o-visual-effects": "^2.0.0",
-    "o-grid": "^4.3.6"
+    "o-grid": "^4.3.6",
+    "o-typography": "^5.4.2"
   }
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,10 +1,6 @@
 $o-tooltip-is-silent: false;
 @import '../../main';
 
-body {
-	font-family: MetricWeb;
-}
-
 .demo-tooltip-container {
 	height: 200px;
 	width: 500px;

--- a/src/scss/tooltip.scss
+++ b/src/scss/tooltip.scss
@@ -1,4 +1,7 @@
 @import "o-overlay/main";
+//
+$o-typography-is-silent: true;
+@import "o-typography/main";
 
 /// Base tooltip style. Inherits from oOverlay.
 @mixin oTooltip {
@@ -14,6 +17,7 @@
 /// Base tooltip content style. Inherits from oOverlay.
 @mixin oTooltipContent {
 	@include oOverlayContent;
+	@include oTypographySans(0);
 	// Breaks long words to fit into smaller screen sizes
 	hyphens: auto;
 	// Override padding provided for o-overlay which is too big


### PR DESCRIPTION
Adding o-typography here as the base for the tooltip content. As mentioned in #47, this will be subject to branding updates, but should be in here for now. 

Closes #47 