### PR TITLE
Allow tooltip to be created directly in the body

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,25 @@ Since this creates the tooltip from scratch, it is important to include any decl
 
 - `content`: Required. String. This is the content that will be displayed in the tooltip.
 
+#### Create tooltip directly in the body
+
+There are situations when a tooltip cannot be displayed next to an element (i.e: the parent of the element has `overlow: hidden`). For these type of situations the tooltip can be instantiated using the `appendToBody` configuration property, which will force the tooltip element to be created just before `body` tag closing.
+
+```js
+const Tooltip = require('o-tooltip');
+const tooltipEl = document.querySelector('.imperative-tooltip-element');
+const opts = {
+	target: 'tooltip-target-imperative',
+	content: 'Click to save to somewhere',
+	showOnConstruction: true,
+	position: 'above',
+	appendToBody: true
+}
+const tooltip = new Tooltip(tooltipEl, opts);
+```
+
+*Note! this property can only be used only when constructing the tooltip declaratively*
+
 #### Firing an oDomContentLoaded event
 
 ```js

--- a/demos/src/append-to-body.js
+++ b/demos/src/append-to-body.js
@@ -1,12 +1,12 @@
 import Tooltip from './../../main.js';
 
 document.addEventListener('DOMContentLoaded', function () {
-    let tooltipElement = document.querySelector('.imperative-tooltip-target');
-    new Tooltip(tooltipElement, {
-        target: 'tooltip-target-imperative',
-        content: 'Click to save to somewhere',
-        showOnConstruction: true,
-        position: 'above',
-        appendToBody: true
-    });
+	let tooltipElement = document.querySelector('.imperative-tooltip-target');
+	new Tooltip(tooltipElement, {
+		target: 'tooltip-target-imperative',
+		content: 'Click to save to somewhere',
+		showOnConstruction: true,
+		position: 'above',
+		appendToBody: true
+	});
 });

--- a/demos/src/append-to-body.js
+++ b/demos/src/append-to-body.js
@@ -1,0 +1,12 @@
+import Tooltip from './../../main.js';
+
+document.addEventListener('DOMContentLoaded', function () {
+    let tooltipElement = document.querySelector('.imperative-tooltip-target');
+    new Tooltip(tooltipElement, {
+        target: 'tooltip-target-imperative',
+        content: 'Click to save to somewhere',
+        showOnConstruction: true,
+        position: 'above',
+        appendToBody: true
+    });
+});

--- a/demos/src/no-markup.mustache
+++ b/demos/src/no-markup.mustache
@@ -1,8 +1,9 @@
-<div class="o-colors-page-background">
-	<div class='demo-tooltip-container' id="box-tooltip">
-
-		<button class='o-buttons o-buttons--big imperative-tooltip-target'>
-			Hover
-		</button>
+<div class='demo-scrollable-container'>
+	<div class="o-colors-page-background">
+		<div class='demo-tooltip-container' id="box-tooltip">
+			<button class='o-buttons o-buttons--big imperative-tooltip-target'>
+				Hover
+			</button>
+		</div>
 	</div>
 </div>

--- a/origami.json
+++ b/origami.json
@@ -59,6 +59,14 @@
 			"description": "Tooltip declared in js, with no markup"
 		},
 		{
+			"title": "Append to body",
+			"name": "append-to-body",
+			"template": "demos/src/no-markup.mustache",
+			"js": "demos/src/append-to-body.js",
+			"description": "Append tooltip to body rather than the target's parent.",
+			"hidden": true
+		},
+		{
 			"title": "Responsive Positioning",
 			"name": "responsive-positioning",
 			"template": "demos/src/responsive-positioning.mustache",

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -366,8 +366,6 @@ class Tooltip {
 			// use absolute coordinates of the target relative to its position inside the page
 			this.tooltipEl.style.top = this.tooltipRect.top + 'px';
 			this.tooltipEl.style.left = this.tooltipRect.left + 'px';
-			// set `fixed` position
-			this.tooltipEl.style.position = 'fixed';
 			// set an ID in order to be identified
 			this.tooltipEl.id = this.opts.target + this.constructor.idSuffix;
 		} else {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -363,15 +363,12 @@ class Tooltip {
 
 		if (this.opts.appendToBody) {
 			// If the tooltip will be apended directly to body:
-			// use absolute coordinates of the target relative to its position inside the page
-			this.tooltipEl.style.top = this.tooltipRect.top + 'px';
-			this.tooltipEl.style.left = this.tooltipRect.left + 'px';
 			// set an ID in order to be identified
 			this.tooltipEl.id = this.opts.target + this.constructor.idSuffix;
-		} else {
-			this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
-			this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
 		}
+
+		this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
+		this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
 
 		// Set Tooltip arrow.
 		this._setArrow();

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -4,8 +4,6 @@ import oGrid from 'o-grid';
 import Target from './target';
 
 class Tooltip {
-	idSufix = '-tooltip';
-
 	static _getCurrentLayout() {
 		return oGrid.getCurrentLayout();
 	}
@@ -588,6 +586,8 @@ class Tooltip {
 		return Array.from(rootEl.querySelectorAll('[data-o-component="o-tooltip"]'), rootEl => new Tooltip(rootEl, opts));
 	}
 }
+
+Tooltip.idSufix = '-tooltip';
 
 Tooltip.arrowDepth = 10;
 Tooltip.positionToArrowPositionMap = {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -140,7 +140,7 @@ class Tooltip {
 		// Make sure the tooltip is attached to the DOM
 		if (this.opts.appendToBody) {
 			// either appended directly into the body
-			if (!document.getElementById(this.opts.target + this.idSuffix)) {
+			if (!document.getElementById(this.opts.target + this.constructor.idSuffix)) {
 				document.body.appendChild(this.tooltipEl);
 			}
 		} else if (this.targetNode && this.targetNode.nextSibling !== this.tooltipEl) {
@@ -369,7 +369,7 @@ class Tooltip {
 			// set `fixed` position
 			this.tooltipEl.style.position = 'fixed';
 			// set an ID in order to be identified
-			this.tooltipEl.id = this.opts.target + this.idSuffix;
+			this.tooltipEl.id = this.opts.target + this.constructor.idSuffix;
 		} else {
 			this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
 			this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -4,6 +4,7 @@ import oGrid from 'o-grid';
 import Target from './target';
 
 class Tooltip {
+	idSufix = '-tooltip';
 
 	static _getCurrentLayout() {
 		return oGrid.getCurrentLayout();
@@ -138,9 +139,14 @@ class Tooltip {
 	 * Render the tooltip. Adds markup and attributes to this.tooltipEl in the DOM
 	*/
 	render() {
-		// make sure the tooltip is the next sibling of the target and (in the case of generated tooltip el)
-		// is attached to the DOM
-		if (this.targetNode && this.targetNode.nextSibling !== this.tooltipEl) {
+		// Make sure the tooltip is attached to the DOM
+		if (this.opts.appendToBody) {
+			// either appended directly into the body
+			if (!document.getElementById(this.opts.target + idSufix)) {
+				document.body.appendChild(this.tooltipEl);
+			}
+		} else if (this.targetNode && this.targetNode.nextSibling !== this.tooltipEl) {
+			// or is the next sibling of the target
 			if (this.targetNode.nextSibling) {
 				this.targetNode.parentNode.insertBefore(this.tooltipEl, this.targetNode.nextSibling);
 			} else {
@@ -356,8 +362,20 @@ class Tooltip {
 		this.tooltipPosition = position;
 		const targetLeftOffset = (this.target.targetEl.offsetParent && this.target.targetEl.offsetParent.getBoundingClientRect().left);
 		const targetTopOffset = (this.target.targetEl.offsetParent && this.target.targetEl.offsetParent.getBoundingClientRect().top);
-		this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
-		this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
+
+		if (this.opts.appendToBody) {
+			// If the tooltip will be apended directly to body:
+			// use absolute coordinates of the target relative to its position inside the page
+			this.tooltipEl.style.top = this.tooltipRect.top + 'px';
+			this.tooltipEl.style.left = this.tooltipRect.left + 'px';
+			// set `fixed` position
+			this.tooltipEl.style.position = 'fixed';
+			// set an ID in order to be identified
+			this.tooltipEl.id = this.opts.target + this.idSufix;
+		} else {
+			this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
+			this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
+		}
 
 		// Set Tooltip arrow.
 		this._setArrow();

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -140,7 +140,7 @@ class Tooltip {
 		// Make sure the tooltip is attached to the DOM
 		if (this.opts.appendToBody) {
 			// either appended directly into the body
-			if (!document.getElementById(this.opts.target + this.constructor.idSuffix)) {
+			if (!document.getElementById(this.opts.target + Tooltip.idSuffix)) {
 				document.body.appendChild(this.tooltipEl);
 			}
 		} else if (this.targetNode && this.targetNode.nextSibling !== this.tooltipEl) {
@@ -364,7 +364,7 @@ class Tooltip {
 		if (this.opts.appendToBody) {
 			// If the tooltip will be apended directly to body:
 			// set an ID in order to be identified
-			this.tooltipEl.id = this.opts.target + this.constructor.idSuffix;
+			this.tooltipEl.id = this.opts.target + Tooltip.idSuffix;
 			this.tooltipEl.style.top = (this.tooltipRect.top + document.documentElement.scrollTop) + 'px';
 			this.tooltipEl.style.left = (this.tooltipRect.left + document.documentElement.scrollLeft) + 'px';
 		} else {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -140,7 +140,7 @@ class Tooltip {
 		// Make sure the tooltip is attached to the DOM
 		if (this.opts.appendToBody) {
 			// either appended directly into the body
-			if (!document.getElementById(this.opts.target + idSufix)) {
+			if (!document.getElementById(this.opts.target + this.idSuffix)) {
 				document.body.appendChild(this.tooltipEl);
 			}
 		} else if (this.targetNode && this.targetNode.nextSibling !== this.tooltipEl) {
@@ -369,7 +369,7 @@ class Tooltip {
 			// set `fixed` position
 			this.tooltipEl.style.position = 'fixed';
 			// set an ID in order to be identified
-			this.tooltipEl.id = this.opts.target + this.idSufix;
+			this.tooltipEl.id = this.opts.target + this.idSuffix;
 		} else {
 			this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
 			this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
@@ -587,7 +587,7 @@ class Tooltip {
 	}
 }
 
-Tooltip.idSufix = '-tooltip';
+Tooltip.idSuffix = '-tooltip';
 
 Tooltip.arrowDepth = 10;
 Tooltip.positionToArrowPositionMap = {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -365,10 +365,12 @@ class Tooltip {
 			// If the tooltip will be apended directly to body:
 			// set an ID in order to be identified
 			this.tooltipEl.id = this.opts.target + this.constructor.idSuffix;
+			this.tooltipEl.style.top = (this.tooltipRect.top + document.documentElement.scrollTop) + 'px';
+			this.tooltipEl.style.left = (this.tooltipRect.left + document.documentElement.scrollLeft) + 'px';
+		} else {
+			this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
+			this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
 		}
-
-		this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
-		this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
 
 		// Set Tooltip arrow.
 		this._setArrow();


### PR DESCRIPTION
Add a new boolean config option - `appendToBody` - to allow a tooltip to be created directly inside the body, independent of the target element positioning