### PR TITLE
Remove use of deprecated colour usecases.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "ftdomdelegate": "^2.2.0",
     "o-normalise": "^1.2.1",
-    "o-overlay": "^v2.6.0",
+    "o-overlay": "^2.6.0",
     "o-viewport": "^3.1.2",
     "o-visual-effects": "^2.0.0",
     "o-grid": "^4.3.6"

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "ftdomdelegate": "^2.2.0",
     "o-normalise": "^1.2.1",
-    "o-overlay": "^v2.5.1",
+    "o-overlay": "^v2.6.0",
     "o-viewport": "^3.1.2",
     "o-visual-effects": "^2.0.0",
     "o-grid": "^4.3.6"

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "ftdomdelegate": "^2.2.0",
     "o-normalise": "^1.2.1",
-    "o-overlay": "^2.0.0",
+    "o-overlay": "^v2.5.1",
     "o-viewport": "^3.1.2",
     "o-visual-effects": "^2.0.0",
     "o-grid": "^4.3.6"

--- a/demos/src/append-to-body.js
+++ b/demos/src/append-to-body.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	let tooltipElement = document.querySelector('.imperative-tooltip-target');
 	new Tooltip(tooltipElement, {
 		target: 'tooltip-target-imperative',
-		content: 'Click to save to somewhere',
+		content: '<p>Click to save to somewhere</p>',
 		showOnConstruction: true,
 		position: 'above',
 		appendToBody: true

--- a/demos/src/click.mustache
+++ b/demos/src/click.mustache
@@ -10,7 +10,7 @@
 		data-o-tooltip-target="demo-tooltip-target"
 		data-o-tooltip-show-on-click="true">
 			<div class='o-tooltip-content'>
-				Share this article via email
+				<p>Share this article via email</p>
 			</div>
 		</div>
 	</div>

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -10,7 +10,7 @@
 		data-o-tooltip-target="demo-tooltip-target"
 		data-o-tooltip-show-on-construction="true">
 			<div class='o-tooltip-content'>
-				supercalifragilisticexpialidocious
+				<p>supercalifragilisticexpialidocious</p>
 			</div>
 		</div>
 	</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,10 +1,6 @@
 $o-tooltip-is-silent: false;
 @import '../../main';
 
-body {
-	font-family: MetricWeb;
-}
-
 .demo-tooltip-container {
 	height: 200px;
 	display: inline-block;

--- a/demos/src/fixed.mustache
+++ b/demos/src/fixed.mustache
@@ -10,7 +10,7 @@
              data-o-tooltip-target="demo-tooltip-target"
              data-o-tooltip-show-on-click="true">
             <div class='o-tooltip-content'>
-                Share this article via email.
+                <p>Share this article via email.</p>
             </div>
         </div>
     </div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -12,7 +12,7 @@
 			data-o-tooltip-target="demo-tooltip-target"
 			data-o-tooltip-show-on-click="true">
 				<div class='o-tooltip-content'>
-					Share this article via email
+					<p>Share this article via email</p>
 				</div>
 			</div>
 		</div>

--- a/demos/src/relative-position-test.mustache
+++ b/demos/src/relative-position-test.mustache
@@ -12,7 +12,7 @@
 			data-o-tooltip-target="demo-tooltip-target"
 			data-o-tooltip-show-on-click="true">
 				<div class='o-tooltip-content'>
-					Share this article via email
+					<p>Share this article via email</p>
 				</div>
 			</div>
 		</div>

--- a/demos/src/responsive-positioning.mustache
+++ b/demos/src/responsive-positioning.mustache
@@ -14,7 +14,7 @@
 		data-o-tooltip-target="demo-tooltip-target"
 		data-o-tooltip-show-on-construction="true">
 			<div class='o-tooltip-content'>
-				Spin me right round..
+				<p>Spin me right round..</p>
 			</div>
 		</div>
 	</div>

--- a/demos/src/scroll-test.mustache
+++ b/demos/src/scroll-test.mustache
@@ -11,7 +11,7 @@
 			data-o-tooltip-target="demo-tooltip-target"
 			data-o-tooltip-show-on-click="true">
 				<div class='o-tooltip-content'>
-					Share this article via email
+					<p>Share this article via email</p>
 				</div>
 			</div>
 		</div>

--- a/demos/src/timeout.mustache
+++ b/demos/src/timeout.mustache
@@ -11,7 +11,7 @@
              data-o-tooltip-show-on-construction="true"
              data-o-tooltip-close-after="3">
             <div class='o-tooltip-content'>
-                Share this article via email
+                <p>Share this article via email</p>
             </div>
         </div>
         <p>This tooltip will show after 3 seconds</p>
@@ -24,7 +24,7 @@
              data-o-tooltip-target="demo-tooltip-target-2"
              data-o-tooltip-show-after="3">
             <div class='o-tooltip-content'>
-                Share this article via email
+                <p>Share this article via email</p>
             </div>
         </div>
     </div>

--- a/demos/src/toggle.mustache
+++ b/demos/src/toggle.mustache
@@ -12,7 +12,7 @@
             data-o-tooltip-close-after="3"
             data-o-tooltip-show-on-construction="true">
             <div class='o-tooltip-content'>
-                Share this article via email
+                <p>Share this article via email</p>
             </div>
         </div>
     </div>

--- a/origami.json
+++ b/origami.json
@@ -9,6 +9,11 @@
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/ft-origami"
 	},
+	"brands": [
+		"master",
+		"internal",
+		"whitelabel"
+	],
 	"supportStatus": "active",
 	"browserFeatures": {},
 	"ci": {
@@ -17,8 +22,8 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "",
-		"dependencies": "o-fonts@^3.0.0,o-colors@^4.0.0,o-buttons@^5.0.0,o-normalise@^1.0.0"
+		"documentClasses": "o-typography-wrapper",
+		"dependencies": ["o-typography@^5.9.0", "o-colors@^4.0.0", "o-buttons@^5.0.0", "o-normalise@^1.0.0"]
 	},
 	"demos": [
 		{

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,3 +1,7 @@
 $o-tooltip-is-silent: true !default;
 $o-tooltip-animation-distance: 50px;
 $o-tooltip-animation-duration: 0.5s;
+
+/// @access private
+$_o-tooltip-background-color: oColorsGetPaletteColor('white');
+$_o-tooltip-border-color: rgba(0, 0, 0, 0.05);

--- a/src/scss/tooltip.scss
+++ b/src/scss/tooltip.scss
@@ -3,6 +3,7 @@
 /// Base tooltip style. Inherits from oOverlay.
 @mixin oTooltip {
 	@include oOverlay();
+	background: $_o-tooltip-background-color;
 
 	// Override border set in o-overlay
 	border: 0;
@@ -79,8 +80,8 @@
 
 /// Top arrow styling
 ///
-/// @param {Color} color [oColorsGetColorFor(o-overlay, border)]
-@mixin oTooltipUpArrow($color: rgba(0, 0, 0, 0.05)) {
+/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+@mixin oTooltipUpArrow($color: $_o-tooltip-border-color) {
 	@include _oTooltipVerticalArrow;
 
 	&:before,
@@ -92,14 +93,14 @@
 		border-bottom-color: $color;
 	}
 	&:after {
-		border-bottom-color: oColorsGetColorFor(o-overlay, background);
+		border-bottom-color: $_o-tooltip-background-color;
 	}
 }
 
 /// Bottom arrow styling
 ///
-/// @param {Color} color [oColorsGetColorFor(o-overlay, border)]
-@mixin oTooltipDownArrow($color: rgba(0, 0, 0, 0.05)) {
+/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+@mixin oTooltipDownArrow($color: $_o-tooltip-border-color) {
 	@include _oTooltipVerticalArrow;
 
 	&:before,
@@ -111,7 +112,7 @@
 		border-top-color: $color;
 	}
 	&:after {
-		border-top-color: oColorsGetColorFor(o-overlay, background);
+		border-top-color: $_o-tooltip-background-color;
 	}
 }
 
@@ -152,8 +153,8 @@
 
 /// Left arrow styling
 ///
-/// @param {Color} color [oColorsGetColorFor(o-overlay, border)]
-@mixin oTooltipLeftArrow($color: rgba(0, 0, 0, 0.05)) {
+/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+@mixin oTooltipLeftArrow($color: $_o-tooltip-border-color) {
 	@include _oTooltipHorizontalArrow;
 
 	&:before,
@@ -165,14 +166,14 @@
 		border-right-color: $color;
 	}
 	&:after {
-		border-right-color: oColorsGetColorFor(o-overlay, background);
+		border-right-color: $_o-tooltip-background-color;
 	}
 }
 
 /// Right arrow styling
 ///
-/// @param {Color} color [oColorsGetColorFor(o-overlay, border)]
-@mixin oTooltipRightArrow($color: rgba(0, 0, 0, 0.05)) {
+/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+@mixin oTooltipRightArrow($color: $_o-tooltip-border-color) {
 	@include _oTooltipHorizontalArrow;
 
 	&:before,
@@ -184,7 +185,7 @@
 		border-left-color: $color;
 	}
 	&:after {
-		border-left-color: oColorsGetColorFor(o-overlay, background);
+		border-left-color: $_o-tooltip-background-color;
 	}
 }
 


### PR DESCRIPTION
...and add brand support to o-tooltip at the same time (why not).

**[A new minor of `o-overlay` must be released first.](https://github.com/Financial-Times/o-overlay)**

- Removes reliance on the deprecated `o-overlay` colour usecase `oColorsGetColorFor(o-overlay, background)`. This would mean `o-tooltip` would not share a background colour with `o-overlay`, which could be considered  visually breaking, except `o-overlay` hasn't used its own colour usecase for a while. ¯\_(ツ)_/¯
- Moves the shadow colour to a variable. We might want to consider moving the shadow colour into `o-colors` as a usecase, so it can be shared between `o-overlay`, `o-tooltip`, `o-visual-effects`, etc. https://github.com/Financial-Times/o-colors/issues/181
- Uses `o-typography-wrapper` to style the contents of the mixin. The demo used to set `body{ font-family: MetricWeb; }` but this is not suitable for all brands. Unfortunately `o-typography-wrapper` provides a serif font for the master brand, but there are plans to change that in the next major.

**Whitelabel**
<img width="299" alt="screenshot 2019-02-13 at 18 07 56" src="https://user-images.githubusercontent.com/10405691/52734027-12f64f80-2fbc-11e9-9305-2ab065c8fdbf.png">

**Internal**
<img width="256" alt="screenshot 2019-02-13 at 18 08 12" src="https://user-images.githubusercontent.com/10405691/52734031-17226d00-2fbc-11e9-8de1-b46a88c57b7d.png">

**Master**
<img width="312" alt="screenshot 2019-02-13 at 18 21 00" src="https://user-images.githubusercontent.com/10405691/52734055-26a1b600-2fbc-11e9-978a-a834b83724cd.png">
