### PR TITLE
Correct tooltip positioning (account for the arrow position)

### DIFF
--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -327,6 +327,8 @@ class Tooltip {
 	drawTooltip() {
 		// render the tooltip so we know how big it is
 		this.tooltipEl.style.display = 'block';
+		// don't increase in size, i.e due to inline content, after positioning
+		this.tooltipEl.style['max-width'] = `${this.width()}px`;
 		// check bounds for every position (4 counts)
 		// if chosen position cannot fit flip the toolip.
 		let count = 0;
@@ -434,11 +436,14 @@ class Tooltip {
 
 		// Calculate for position above/below.
 		if (axis === 'y') {
+			// the arrow is placed 10% along the body of the tooltip
+			const arrowPosition = (this.width() / 10);
+
 			if (alignment === 'left') {
-				rect.left = this.target.right - this.width();
+				rect.left = this.target.centrePoint.x - this.width() + arrowPosition;
 			}
 			if (alignment === 'right') {
-				rect.left = this.target.left;
+				rect.left = this.target.centrePoint.x - arrowPosition;
 			}
 			if (alignment === 'middle') {
 				rect.left = this.target.centrePoint.x - (this.width() / 2);


### PR DESCRIPTION
**Before:** 
The tooltip arrow is positioned 10% along the tooltip. 
The tooltip edge aligns with the target edge. 
If the target width is less than 10% of the tooltip width, the tooltip 
arrow does not point to the target.

<img width="998" alt="Screenshot 2020-01-17 at 14 23 18" src="https://user-images.githubusercontent.com/10405691/72620894-1dda0280-3938-11ea-8882-ae0fc14a8368.png">
<img width="626" alt="Screenshot 2020-01-17 at 14 23 30" src="https://user-images.githubusercontent.com/10405691/72620895-1dda0280-3938-11ea-816a-f56c491bf68f.png">


**After:** 

The position of the tooltip arrow is considered when placing the tooltip:
<img width="667" alt="Screenshot 2020-01-17 at 14 22 34" src="https://user-images.githubusercontent.com/10405691/72621142-9640c380-3938-11ea-9644-3ae9a2a03ebb.png">
<img width="995" alt="Screenshot 2020-01-17 at 14 22 42" src="https://user-images.githubusercontent.com/10405691/72621144-9640c380-3938-11ea-9ade-89f9225d9da8.png">
