### PR TITLE
Tooltip position 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Attributes can be set declaratively, or passed in on instantiation in an options
 - `data-o-tooltip-close-after`: Optional. Integer value. Specify the number of seconds to wait before closing the tooltip. Only applies when `data-o-tooltip-show-on-construction` is set to `true`
 - `data-o-tooltip-z-index`: Optional. The z-index for the tooltip.
 - `data-o-tooltip-animation-distance`: Optional. String with `px` suffix. Distance away from target to start and end animation. Defaults to '10px'.
+- `data-o-tooltip-append-to-body`: Optional. Append the tooltip to the `body` element so it is positioned and sized according to the body rather than a parent element. By default the tooltip is appended as a sibling of the tooltip target. Defaults to `false`.
 
 ### JavaScript
 

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -360,10 +360,6 @@ class Tooltip {
 			}
 		}
 
-		if (count >= 5) {
-			console.warn("There is not enough space in the client window to draw the tooltip.");
-		}
-
 		// Draw tooltip with latest alignment and position.
 		this.tooltipRect = tooltipRect;
 		this.tooltipAlignment = alignment;
@@ -371,6 +367,7 @@ class Tooltip {
 		const targetLeftOffset = (this.target.targetEl.offsetParent && this.target.targetEl.offsetParent.getBoundingClientRect().left);
 		const targetTopOffset = (this.target.targetEl.offsetParent && this.target.targetEl.offsetParent.getBoundingClientRect().top);
 
+		const startWidth = this.tooltipEl.getBoundingClientRect().width;
 		if (this.opts.appendToBody) {
 			// If the tooltip will be apended directly to body:
 			// set an ID in order to be identified
@@ -381,9 +378,22 @@ class Tooltip {
 			this.tooltipEl.style.top = (this.tooltipRect.top - targetTopOffset) + 'px';
 			this.tooltipEl.style.left = (this.tooltipRect.left - targetLeftOffset) + 'px';
 		}
+		const endWidth = this.tooltipEl.getBoundingClientRect().width;
+
+		// The tooltip size changed when it was placed, e.g. because inline
+		// content overflowed a container and wrapped to more lines.
+		// Redraw with the new tooltip dimensions.
+		if (startWidth !== endWidth) {
+			return this.drawTooltip();
+		}
 
 		// Set Tooltip arrow.
 		this._setArrow();
+
+		// Warn all positions were tried and the tooltip is sill out of bounds.
+		if (count >= 5) {
+			console.warn("There is not enough space in the client window to draw the tooltip.");
+		}
 	}
 
 	/**


### PR DESCRIPTION
 Redraw tooltip when inline content reflows.

When the tooltip is placed in position its content may reflow if
the content is inline. This could change the height of the
tooltip and so its position needs to be recalculated.

**Before:**
The text reflows after positioning and does not align with the target.
<img width="510" alt="Screenshot 2020-01-20 at 13 16 46" src="https://user-images.githubusercontent.com/10405691/72730425-486eca00-3b89-11ea-8aea-d2fe57e29cab.png">

**Now:**
The redraw method is called again to reposition the tooltip after reflow:
<img width="510" alt="Screenshot 2020-01-20 at 13 17 28" src="https://user-images.githubusercontent.com/10405691/72730477-5b819a00-3b89-11ea-9767-36325f9f3da1.png">


**Now, with and without "append to body" option:**
<img width="1220" alt="Screenshot 2020-01-20 at 13 20 35" src="https://user-images.githubusercontent.com/10405691/72730357-25dcb100-3b89-11ea-84b8-b1d1775a9cd9.png">
<img width="1220" alt="Screenshot 2020-01-20 at 13 20 21" src="https://user-images.githubusercontent.com/10405691/72730355-25441a80-3b89-11ea-80d3-495b8944b039.png">