### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/Target.test.js
+++ b/test/Target.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, proclaim */
+/* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import * as fixtures from './helpers/fixtures';
 
 import Target from'./../src/js/target';

--- a/test/Tooltip.test.js
+++ b/test/Tooltip.test.js
@@ -1,8 +1,8 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
-import createMockRaf from 'mock-raf';
+import {createMockRaf} from './helpers/mock-raf';
 import Tooltip from './../main';
 import Viewport from 'o-viewport';
 
@@ -11,7 +11,7 @@ describe("Tooltip", () => {
 	let sandbox;
 
 	beforeEach(() => {
-		sandbox = sinon.sandbox.create();
+		sandbox = sinon.createSandbox();
 	});
 
 	afterEach(() => {
@@ -197,6 +197,7 @@ describe("Tooltip", () => {
 			const options = Tooltip.getOptions(el);
 			proclaim.isTrue(options.showOnConstruction);
 		});
+
 		it("extracts showOnConstruction if it's set on the el passed in", () => {
 			const el = document.createElement('div');
 			el.setAttribute('data-o-tooltip-z-index', "20");

--- a/test/helpers/mock-raf.js
+++ b/test/helpers/mock-raf.js
@@ -1,0 +1,50 @@
+export function createMockRaf () {
+	let allCallbacks = {};
+	let callbacksLength = 0;
+
+	let now = 0;
+
+	const getNow = function () {
+		return now;
+	};
+
+	const raf = function (callback) {
+		callbacksLength += 1;
+
+		allCallbacks[callbacksLength] = callback;
+
+		return callbacksLength;
+	};
+
+	const cancel = function (id) {
+		delete allCallbacks[id];
+	};
+
+	const step = function (opts) {
+		const options = Object.assign({
+			time: 1000 / 60,
+			count: 1
+		}, opts);
+
+		let oldAllCallbacks;
+
+		for (let i = 0; i < options.count; i++) {
+			oldAllCallbacks = allCallbacks;
+			allCallbacks = {};
+
+			now += options.time;
+
+			for (const id of Object.keys(oldAllCallbacks)) {
+				const callback = oldAllCallbacks[id];
+				callback(now);
+			}
+		}
+	};
+
+	return {
+		now: getNow,
+		raf: raf,
+		cancel: cancel,
+		step: step
+	};
+}

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
 
 import Tooltip from './../main';


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.