### PR TITLE
Remove the huge scroll container from the "no-markup" demo

### DIFF
--- a/demos/src/no-markup.mustache
+++ b/demos/src/no-markup.mustache
@@ -1,9 +1,7 @@
-<div class='demo-scrollable-container'>
-	<div class="o-colors-page-background">
-		<div class='demo-tooltip-container' id="box-tooltip">
-			<button class='o-buttons o-buttons--secondary o-buttons--big imperative-tooltip-target'>
-				Hover
-			</button>
-		</div>
+<div class="o-colors-page-background">
+	<div class='demo-tooltip-container' id="box-tooltip">
+		<button class='o-buttons o-buttons--secondary o-buttons--big imperative-tooltip-target'>
+			Hover
+		</button>
 	</div>
 </div>


### PR DESCRIPTION
https://registry.origami.ft.com/components/o-tooltip@4.0.6#demo-no-markup
<img width="306" alt="Screenshot 2020-06-18 at 11 40 28" src="https://user-images.githubusercontent.com/10405691/85010850-a0b9f000-b158-11ea-89b8-23cbc10ea298.png">
