### PR TITLE
ENT-167 Add support for mixin arguments for text and background colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
 ### Sass
 
-#### Mixin: `oTooltip`
-
 The `oTooltip` mixin is used to output tooltip selectors and styles. This output includes all of the `.o-tooltip` classes:
 
 ```scss
@@ -138,6 +136,29 @@ The `oTooltip` mixin is used to output tooltip selectors and styles. This output
 ```
 
 There is [full Sass documentation available in the Origami Registry](https://registry.origami.ft.com/components/o-tooltip/sassdoc).
+
+## Customisation
+
+Include the `oTooltipAddTheme` mixin to output a custom tooltip theme. The mixin accepts a name for your theme and a map of options:
+
+- `name`: The name of your theme. This is used for the modifier class output `o-tooltip--[name]`.
+- `opts`: A map of options for your theme.
+	- `background-color`: The background color for your tooltip.
+	- `foreground-color`: The foreground/text color for your tooltip.
+	- `close-foreground-color` (optional): The colour of the close button. If not set the `foreground-color` is used.
+
+The following example shows how to add a custom theme named "my-product-modifier", with a slate background and white foreground. Instead of "my-product-modifier" choose a descriptive name that includes your project name, so it's clear where the custom theme is added.
+
+```scss
+// Outputs CSS class o-tooltip--my-product-modifier.
+// Uses an o-colors function to fetch Origami colour values.
+@include oTooltipAddTheme('my-product-modifier', (
+	'background-color': oColorsByName('slate'),
+	'foreground-color': oColorsByName('white')
+));
+```
+
+This will output a CSS class `o-tooltip--[name]`. Add this class to your tooltip to view your custom theme.
 
 ## Migration Guide
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-o-tooltip [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
-=================
+# o-tooltip [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
+
 
 o-tooltip is a component usually used for annotating or highlighting bits of user interface.
 

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "o-visual-effects": "^3.0.0",
     "o-grid": "^5.0.2",
     "o-typography": "^6.0.0",
-    "o-overlay": "^3.0.0"
+    "o-brand": "^3.3.0"
   }
 }

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,0 +1,18 @@
+<div class="o-colors-page-background">
+	<div class='demo-tooltip-container' id="box-tooltip">
+
+		<button class='o-buttons o-buttons--secondary o-buttons--big demo-tooltip-target' id="demo-tooltip-target">
+			Share
+		</button>
+
+		<div data-o-component="o-tooltip"
+		data-o-tooltip-position="right"
+		data-o-tooltip-target="demo-tooltip-target"
+		data-o-tooltip-show-on-click="true"
+		class="o-tooltip--demo-custom-theme">
+			<div class='o-tooltip-content'>
+				<p>The style of this tooltip is customised using the tooltip Sass API.</p>
+			</div>
+		</div>
+	</div>
+</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -44,6 +44,6 @@ body {
 
 
 @include oTooltipAddTheme('demo-custom-theme', (
-	'background-color': oColorsByName('black'),
+	'background-color': oColorsByName('slate'),
 	'foreground-color': oColorsByName('white')
 ));

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -44,6 +44,6 @@ body {
 
 
 @include oTooltipAddTheme('demo-custom-theme', (
-	'background-color': oColorsByName('slate'),
+	'background-color': oColorsByName('black'),
 	'foreground-color': oColorsByName('white')
 ));

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -41,3 +41,9 @@ body {
 	position: fixed;
 	top: 0;
 }
+
+
+@include oTooltipAddTheme('demo-custom-theme', (
+	'background-color': oColorsByName('black'),
+	'foreground-color': oColorsByName('white')
+));

--- a/main.scss
+++ b/main.scss
@@ -87,6 +87,36 @@
 		}
 	}
 
+	.o-tooltip--arrow-left,
+	.o-tooltip--arrow-right {
+
+		&.o-tooltip-arrow--align-top:before,
+		&.o-tooltip-arrow--align-top:after {
+			top: 0;
+			margin-top: 0;
+		}
+
+		&.o-tooltip-arrow--align-bottom:before,
+		&.o-tooltip-arrow--align-bottom:after {
+			top: auto;
+			bottom: 0;
+			margin-top: 0;
+		}
+
+
+		&:before,
+		&:after {
+			top: 50%;
+		}
+		&:before {
+			// 1px offset so it appears properly
+			margin-top: -$_o-tooltip-arrow-size - $_o-tooltip-border-width - 1;
+		}
+		&:after {
+			margin-top: -$_o-tooltip-arrow-size;
+		}
+	}
+
 	.o-tooltip--arrow-left {
 		&:before,
 		&:after {

--- a/main.scss
+++ b/main.scss
@@ -1,28 +1,196 @@
+@import "o-brand/main";
 @import "o-grid/main";
 @import "o-normalise/main";
-@import "o-overlay/main";
 @import "o-visual-effects/main";
 @import "o-typography/main";
 
 @import "src/scss/variables";
+@import "src/scss/brand";
 @import "src/scss/mixins";
 
 /// Outputs all available features and styles for tooltips.
 ///
-/// @param {Color} tooltip-background-color [$_o-tooltip-background-color] - The background color of the tooltip.
-/// @param {Color} text-color [$_o-tooltip-text-color] - The color of the tooltip text.
 /// @output The output includes the `.o-tooltip` class definition.
 /// @example scss - All tooltip styles
 ///   @include oTooltip();
 /// @access public
-@mixin oTooltip($tooltip-background-color: $_o-tooltip-background-color, $text-color: $_o-tooltip-text-color) {
+@mixin oTooltip() {
 	// Tooltip relies on the o-grid layout sizes being defined.
 	// This is still spec-compliant, as these mixins only output
 	// element selectors – nothing prefixed with o-grid
 	@include oGridSurfaceCurrentLayout();
 
-	// Include base styles
-	@include _oTooltipBase($tooltip-background-color, $text-color);
+	.o-tooltip {
+		@include oVisualEffectsShadowContent($elevation: 'high');
+		position: absolute;
+		z-index: 10;
+		box-sizing: border-box;
+		opacity: 0;
+		transition: opacity $_o-tooltip-animation-duration $o-visual-effects-timing-fade, transform $_o-tooltip-animation-duration $o-visual-effects-timing-slide;
+		border: 0;
+		display: none;
+
+		&.visible {
+			transform: translate(0, 0);
+			opacity: 1;
+		}
+
+		&[data-o-tooltip-position="left"]:not(.visible) {
+			transform: translate(-$_o-tooltip-animation-distance, 0);
+		}
+		&[data-o-tooltip-position="right"]:not(.visible) {
+			transform: translate($_o-tooltip-animation-distance, 0);
+		}
+		&[data-o-tooltip-position="top"]:not(.visible) {
+			transform: translate(0, -$_o-tooltip-animation-distance);
+		}
+		&[data-o-tooltip-position="bottom"]:not(.visible) {
+			transform: translate(0, $_o-tooltip-animation-distance);
+		}
+
+		// Style for the default theme.
+		@include _oTooltipThemeContent();
+	}
+
+	.o-tooltip-content {
+		@include oTypographySans();
+		position: relative;
+		box-sizing: border-box;
+		overflow: auto;
+		padding: 15px 35px 15px 20px;
+		float: left;
+		line-height: 1;
+		hyphens: auto; // Breaks long words to fit into smaller screen sizes
+
+		> *:first-child {
+			margin-top: 0;
+		}
+		> *:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.o-tooltip--arrow-above,
+	.o-tooltip--arrow-below,
+	.o-tooltip--arrow-left,
+	.o-tooltip--arrow-right {
+		&:before,
+		&:after {
+			content: "";
+			position: absolute;
+			border: solid transparent;
+		}
+		&:before {
+			// 1px offset so it appears properly
+			border-width: $_o-tooltip-arrow-size + $_o-tooltip-border-width + 1;
+		}
+		&:after {
+			border-width: $_o-tooltip-arrow-size;
+		}
+	}
+
+	.o-tooltip--arrow-left {
+		&:before,
+		&:after {
+			right: 100%;
+			border-left-width: 0;
+		}
+		&:before {
+			border-right-color: $_o-tooltip-shadow-color;
+		}
+	}
+
+	.o-tooltip--arrow-right {
+		&:before,
+		&:after {
+			left: 100%;
+			border-right-width: 0;
+		}
+		&:before {
+			border-left-color: $_o-tooltip-shadow-color;
+		}
+	}
+
+	.o-tooltip--arrow-above,
+	.o-tooltip--arrow-below {
+		&.o-tooltip-arrow--align-left:before,
+		&.o-tooltip-arrow--align-left:after {
+			left: 10%;
+		}
+
+		&.o-tooltip-arrow--align-right:before,
+		&.o-tooltip-arrow--align-right:after {
+			left: 90%;
+		}
+
+		&:before,
+		&:after {
+			left: 50%;
+		}
+		&:before {
+			// 1px offset so it appears properly
+			margin-left: -$_o-tooltip-arrow-size - $_o-tooltip-border-width - 1;
+		}
+		&:after {
+			margin-left: -$_o-tooltip-arrow-size;
+		}
+	}
+
+	.o-tooltip--arrow-above {
+		&:before,
+		&:after {
+			bottom: 100%;
+			border-top-width: 0;
+		}
+		&:before {
+			border-bottom-color: $_o-tooltip-shadow-color;
+		}
+	}
+
+	.o-tooltip--arrow-below {
+		&:before,
+		&:after {
+			top: 100%;
+			border-bottom-width: 0;
+		}
+		&:before {
+			border-top-color: $_o-tooltip-shadow-color;
+		}
+	}
+
+	.o-tooltip-close {
+		@include oIconsContent(
+			'cross',
+			_oTooltipGet('close-foreground-color'),
+			$size: 20px
+		);
+		// start: undo button styles
+		appearance: none;
+		border: 0;
+		font: inherit;
+		outline: inherit;
+		// end: undo button styles
+		box-sizing: content-box;
+		position: absolute;
+		margin: 5px 5px 15px 15px;
+		padding: 0;
+		cursor: pointer;
+		font-size: 8px;
+		line-height: 1;
+		user-select: none;
+		top: 0;
+		right: 0;
+
+		// Increase hit zone of the button around it for better usability
+		&:after {
+			position: absolute;
+			content: '';
+			top: -(oSpacingByName('s3'));
+			right: -(oSpacingByName('s3'));
+			left: -(oSpacingByName('s3'));
+			bottom: -(oSpacingByName('s3'));
+		}
+	}
 }
 
 // If silent mode is disabled, output all of the default tooltip styles.

--- a/main.scss
+++ b/main.scss
@@ -22,6 +22,7 @@
 
 	.o-tooltip {
 		@include oVisualEffectsShadowContent($elevation: 'high');
+		@include _oTooltipThemeContent(); // Style for the default theme.
 		position: absolute;
 		z-index: 10;
 		box-sizing: border-box;
@@ -47,9 +48,6 @@
 		&[data-o-tooltip-position="bottom"]:not(.visible) {
 			transform: translate(0, $_o-tooltip-animation-distance);
 		}
-
-		// Style for the default theme.
-		@include _oTooltipThemeContent();
 	}
 
 	.o-tooltip-content {

--- a/main.scss
+++ b/main.scss
@@ -9,18 +9,20 @@
 
 /// Outputs all available features and styles for tooltips.
 ///
+/// @param {Color} tooltip-background-color [$_o-tooltip-background-color] - The background color of the tooltip.
+/// @param {Color} text-color [$_o-tooltip-text-color] - The color of the tooltip text.
 /// @output The output includes the `.o-tooltip` class definition.
 /// @example scss - All tooltip styles
 ///   @include oTooltip();
 /// @access public
-@mixin oTooltip() {
+@mixin oTooltip($tooltip-background-color: $_o-tooltip-background-color, $text-color: $_o-tooltip-text-color) {
 	// Tooltip relies on the o-grid layout sizes being defined.
 	// This is still spec-compliant, as these mixins only output
 	// element selectors – nothing prefixed with o-grid
 	@include oGridSurfaceCurrentLayout();
 
 	// Include base styles
-	@include _oTooltipBase();
+	@include _oTooltipBase($tooltip-background-color, $text-color);
 }
 
 // If silent mode is disabled, output all of the default tooltip styles.

--- a/origami.json
+++ b/origami.json
@@ -72,18 +72,25 @@
 			"description": "Tooltip declared in js, with no markup"
 		},
 		{
+			"title": "Responsive Positioning",
+			"name": "responsive-positioning",
+			"template": "demos/src/responsive-positioning.mustache",
+			"description": "Responsive positioning"
+		},
+		{
+			"title": "Custom Tooltip Theme",
+			"name": "custom",
+			"template": "demos/src/custom.mustache",
+			"display_html": false,
+			"description": "A custom theme added using the tooltip Sass API."
+		},
+		{
 			"title": "Append to body",
 			"name": "append-to-body",
 			"template": "demos/src/no-markup.mustache",
 			"js": "demos/src/append-to-body.js",
 			"description": "Append tooltip to body rather than the target's parent.",
 			"hidden": true
-		},
-		{
-			"title": "Responsive Positioning",
-			"name": "responsive-positioning",
-			"template": "demos/src/responsive-positioning.mustache",
-			"description": "Responsive positioning"
 		},
 		{
 			"title": "Scroll Test",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,0 +1,44 @@
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTooltipGet($variables, $from: null) {
+	@return oBrandGet($component: 'o-tooltip', $variables: $variables, $from: $from);
+}
+
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTooltipSupports($variant) {
+	@return oBrandSupportsVariant($component: 'o-tooltip', $variant: $variant);
+}
+
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-tooltip', 'master', (
+		'variables': (
+            'background-color': oColorsByName('white'),
+            'foreground-color': null, // inherit by default
+            'close-foreground-color': oColorsByName('black-60')
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-tooltip', 'internal', (
+		'variables': (
+            'background-color': oColorsByName('white'),
+            'foreground-color': null, // inherit by default
+            'close-foreground-color': oColorsByName('black-60')
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'whitelabel' {
+	@include oBrandDefine('o-tooltip', 'whitelabel', (
+		'variables': (
+            'background-color': oColorsByName('white'),
+            'foreground-color': null, // inherit by default,
+			'close-foreground-color': oColorsByName('black')
+		),
+		'supports-variants': ()
+	));
+}

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -13,9 +13,9 @@
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-tooltip', 'master', (
 		'variables': (
-            'background-color': oColorsByName('white'),
-            'foreground-color': null, // inherit by default
-            'close-foreground-color': oColorsByName('black-60')
+			'background-color': oColorsByName('white'),
+			'foreground-color': null, // inherit by default
+			'close-foreground-color': oColorsByName('black-60')
 		),
 		'supports-variants': ()
 	));
@@ -24,9 +24,9 @@
 @if oBrandGetCurrentBrand() == 'internal' {
 	@include oBrandDefine('o-tooltip', 'internal', (
 		'variables': (
-            'background-color': oColorsByName('white'),
-            'foreground-color': null, // inherit by default
-            'close-foreground-color': oColorsByName('black-60')
+			'background-color': oColorsByName('white'),
+			'foreground-color': null, // inherit by default
+			'close-foreground-color': oColorsByName('black-60')
 		),
 		'supports-variants': ()
 	));
@@ -35,8 +35,8 @@
 @if oBrandGetCurrentBrand() == 'whitelabel' {
 	@include oBrandDefine('o-tooltip', 'whitelabel', (
 		'variables': (
-            'background-color': oColorsByName('white'),
-            'foreground-color': null, // inherit by default,
+			'background-color': oColorsByName('white'),
+			'foreground-color': null, // inherit by default,
 			'close-foreground-color': oColorsByName('black')
 		),
 		'supports-variants': ()

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,11 +1,13 @@
 
 /// Base styles for tooltips.
 ///
+/// @param {Color} tooltip-background-color [$_o-tooltip-background-color] - The background color of the tooltip.
+/// @param {Color} text-color [$_o-tooltip-text-color] - The tooltip text color.
 /// @output The output includes all selectors and styles for tooltips.
 /// @example scss - Base tooltip styles
 ///   @include _oTooltipBase();
 /// @access private
-@mixin _oTooltipBase {
+@mixin _oTooltipBase($tooltip-background-color: $_o-tooltip-background-color, $text-color: $_o-tooltip-text-color) {
 	.o-tooltip {
 		@include oVisualEffectsShadowContent($elevation: 'high');
 		position: absolute;
@@ -14,7 +16,7 @@
 		opacity: 0;
 		transition: opacity $_o-tooltip-animation-duration $o-visual-effects-timing-fade, transform $_o-tooltip-animation-duration $o-visual-effects-timing-slide;
 		border: 0;
-		background: $_o-tooltip-background-color;
+		background: $tooltip-background-color;
 		display: none;
 
 		&.visible {
@@ -36,19 +38,19 @@
 		}
 	}
 	.o-tooltip-content {
-		@include _oTooltipContentBody();
+		@include _oTooltipContentBody($text-color);
 	}
 	.o-tooltip--arrow-left {
-		@include _oTooltipContentLeftArrow();
+		@include _oTooltipContentLeftArrow($tooltip-background-color);
 	}
 	.o-tooltip--arrow-right {
-		@include _oTooltipContentRightArrow();
+		@include _oTooltipContentRightArrow($tooltip-background-color);
 	}
 	.o-tooltip--arrow-above {
-		@include _oTooltipContentUpArrow();
+		@include _oTooltipContentUpArrow($tooltip-background-color);
 	}
 	.o-tooltip--arrow-below {
-		@include _oTooltipContentDownArrow();
+		@include _oTooltipContentDownArrow($tooltip-background-color);
 	}
 	.o-tooltip-close {
 		@include _oTooltipContentClose();
@@ -59,8 +61,9 @@
 ///
 /// @output The output includes all styles for tooltip content excluding a wrapping selector.
 /// @access private
-@mixin _oTooltipContentBody() {
+@mixin _oTooltipContentBody($text-color: $_o-tooltip-text-color) {
 	@include oTypographySans();
+	color: $text-color;
 	position: relative;
 	box-sizing: border-box;
 	overflow: auto;
@@ -133,10 +136,11 @@
 
 /// Outputs base styles for top tooltip arrows.
 ///
-/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
+/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
 /// @output The output includes all styles for top tooltip arrows excluding a wrapping selector.
 /// @access private
-@mixin _oTooltipContentUpArrow($color: $_o-tooltip-border-color) {
+@mixin _oTooltipContentUpArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
 	@include _oTooltipContentVerticalArrow;
 
 	&:before,
@@ -145,19 +149,20 @@
 		border-top-width: 0;
 	}
 	&:before {
-		border-bottom-color: $color;
+		border-bottom-color: $shadow-color;
 	}
 	&:after {
-		border-bottom-color: $_o-tooltip-background-color;
+		border-bottom-color: $color;
 	}
 }
 
 /// Outputs base styles for bottom tooltip arrows.
 ///
-/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
+/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
 /// @output The output includes all styles for bottom tooltip arrows excluding a wrapping selector.
 /// @access private
-@mixin _oTooltipContentDownArrow($color: $_o-tooltip-border-color) {
+@mixin _oTooltipContentDownArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
 	@include _oTooltipContentVerticalArrow;
 
 	&:before,
@@ -166,10 +171,10 @@
 		border-bottom-width: 0;
 	}
 	&:before {
-		border-top-color: $color;
+		border-top-color: $shadow-color;
 	}
 	&:after {
-		border-top-color: $_o-tooltip-background-color;
+		border-top-color: $color;
 	}
 }
 
@@ -210,10 +215,11 @@
 
 /// Outputs base styles for left tooltip arrows.
 ///
-/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
+/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
 /// @output The output includes all styles for left tooltip arrows excluding a wrapping selector.
 /// @access private
-@mixin _oTooltipContentLeftArrow($color: $_o-tooltip-border-color) {
+@mixin _oTooltipContentLeftArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
 	@include _oTooltipContentHorizontalArrow;
 
 	&:before,
@@ -222,19 +228,20 @@
 		border-left-width: 0;
 	}
 	&:before {
-		border-right-color: $color;
+		border-right-color: $shadow-color;
 	}
 	&:after {
-		border-right-color: $_o-tooltip-background-color;
+		border-right-color: $color;
 	}
 }
 
 /// Outputs base styles for right tooltip arrows.
 ///
-/// @param {Color} color [$_o-tooltip-border-color] - The color of the arrow shadow.
+/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
+/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
 /// @output The output includes all styles for right tooltip arrows excluding a wrapping selector.
 /// @access private
-@mixin _oTooltipContentRightArrow($color: $_o-tooltip-border-color) {
+@mixin _oTooltipContentRightArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
 	@include _oTooltipContentHorizontalArrow;
 
 	&:before,
@@ -243,19 +250,21 @@
 		border-right-width: 0;
 	}
 	&:before {
-		border-left-color: $color;
+		border-left-color: $shadow-color;
 	}
 	&:after {
-		border-left-color: $_o-tooltip-background-color;
+		border-left-color: $color;
 	}
 }
 
 /// Outputs base styles for tooltip close buttons.
 ///
+/// @param {Color} color [$_o-tooltip-text-color] - The color of the close icon.
 /// @output The output includes all styles for top tooltip arrows excluding a wrapping selector.
 /// @access private
-@mixin _oTooltipContentClose() {
-	@include oOverlayContentClose;
+@mixin _oTooltipContentClose($color: $_o-tooltip-text-color) {
+	// TODO add support for passing color to close button
+	@include oOverlayContentClose; // ($color);
 	position: absolute;
 	top: 0;
 	right: 0;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,274 +1,88 @@
-
-/// Base styles for tooltips.
-///
-/// @param {Color} tooltip-background-color [$_o-tooltip-background-color] - The background color of the tooltip.
-/// @param {Color} text-color [$_o-tooltip-text-color] - The tooltip text color.
-/// @output The output includes all selectors and styles for tooltips.
-/// @example scss - Base tooltip styles
-///   @include _oTooltipBase();
-/// @access private
-@mixin _oTooltipBase($tooltip-background-color: $_o-tooltip-background-color, $text-color: $_o-tooltip-text-color) {
-	.o-tooltip {
-		@include oVisualEffectsShadowContent($elevation: 'high');
-		position: absolute;
-		z-index: 10;
-		box-sizing: border-box;
-		opacity: 0;
-		transition: opacity $_o-tooltip-animation-duration $o-visual-effects-timing-fade, transform $_o-tooltip-animation-duration $o-visual-effects-timing-slide;
-		border: 0;
-		background: $tooltip-background-color;
-		display: none;
-
-		&.visible {
-			transform: translate(0, 0);
-			opacity: 1;
-		}
-
-		&[data-o-tooltip-position="left"]:not(.visible) {
-			transform: translate(-$_o-tooltip-animation-distance, 0);
-		}
-		&[data-o-tooltip-position="right"]:not(.visible) {
-			transform: translate($_o-tooltip-animation-distance, 0);
-		}
-		&[data-o-tooltip-position="top"]:not(.visible) {
-			transform: translate(0, -$_o-tooltip-animation-distance);
-		}
-		&[data-o-tooltip-position="bottom"]:not(.visible) {
-			transform: translate(0, $_o-tooltip-animation-distance);
-		}
+/// Output styles for a custom o-tooltip theme.
+/// @param {string} $name - The name of the custom theme. This is used to create a new CSS class name so should be descriptive and include the project name.
+/// @param {map} $opts - A map of theme options including "background-color" (color), "foreground-color" (color), and optionally "close-foreground-color" (color).
+/// @example Output a custom tooltip theme named "my-product-modifier" with a slate background, and white foreground. Outputs a class 'o-tooltip--my-product-modifier'
+/// 	// Outputs CSS class "o-tooltip--my-product-modifier"
+/// 	@include oTooltipAddTheme('my-product-modifier', (
+/// 		'background-color': oColorsByName('slate'),
+/// 		'foreground-color': oColorsByName('white'),
+/// 		'close-foreground-color': oColorsByName('white') // optional
+/// 	));
+/// @access public
+@mixin oTooltipAddTheme($name, $opts) {
+	@if type-of($name) != 'string' {
+		@error 'Expected a custom tooltip name as a string.';
 	}
+
+	@if type-of($opts) != 'map' {
+		@error 'Expected a map of tooltip theme options.';
+	}
+
+	@if type-of(map-get($opts, 'background-color')) != 'color' {
+		@error 'Could not add custom tooltip theme "#{$name}". Expected a ' +
+		'a "color" `background-colour` option. Found type ' +
+		'"#{type-of(map-get($opts, 'background-color'))}".';
+	}
+
+	@if type-of(map-get($opts, 'foreground-color')) != 'color' {
+		@error 'Could not add custom tooltip theme "#{$name}". Expected a ' +
+		'a "color" `foreground-colour` option. Found type ' +
+		'"#{type-of(map-get($opts, 'foreground-color'))}".';
+	}
+
+	.o-tooltip.o-tooltip--#{$name} {
+		@include _oTooltipThemeContent($opts);
+	}
+}
+
+/// Output styles required to theme the tooltip.
+/// @example Output styles for the default theme.
+/// 	@include _oTooltipThemeContent();
+/// @example Output styles for an o-brand variant (example only, at the time of writing o-tooltip only has one, default variant).
+/// 	@include _oTooltipThemeContent('inverse');
+/// @example Output styles for a custom variant
+/// 	@include _oTooltipThemeContent((
+/// 		'background-color': oColorsByName('slate'),
+/// 		'foreground-color': oColorsByName('white'),
+/// 		'close-foreground-color': oColorsByName('white') // optional
+/// 	));
+/// @see {oTooltipAddTheme}
+/// @access public
+@mixin _oTooltipThemeContent($theme: null) {
+	// Default theme values.
+	@if(type-of($theme) == 'map') {
+		$theme: map-merge((
+			'close-foreground-color': map-get($theme, 'foreground-color')
+		), $theme);
+	}
+
+	// Output theme CSS.
+	background: _oTooltipGet('background-color', $theme);
+
+	&.o-tooltip--arrow-left:after {
+		border-right-color: _oTooltipGet('background-color', $theme);
+	}
+	&.o-tooltip--arrow-right:after {
+		border-left-color: _oTooltipGet('background-color', $theme);
+	}
+	&.o-tooltip--arrow-above:after {
+		border-bottom-color: _oTooltipGet('background-color', $theme);
+	}
+	&.o-tooltip--arrow-below:after {
+		border-top-color: _oTooltipGet('background-color', $theme);
+	}
+
 	.o-tooltip-content {
-		@include _oTooltipContentBody($text-color);
+		color: _oTooltipGet('foreground-color', $theme);
 	}
-	.o-tooltip--arrow-left {
-		@include _oTooltipContentLeftArrow($tooltip-background-color);
-	}
-	.o-tooltip--arrow-right {
-		@include _oTooltipContentRightArrow($tooltip-background-color);
-	}
-	.o-tooltip--arrow-above {
-		@include _oTooltipContentUpArrow($tooltip-background-color);
-	}
-	.o-tooltip--arrow-below {
-		@include _oTooltipContentDownArrow($tooltip-background-color);
-	}
+
 	.o-tooltip-close {
-		@include _oTooltipContentClose();
+		@include oIconsContent(
+			'cross',
+			_oTooltipGet('foreground-color', $theme),
+			$size: 20px,
+			$include-base-styles: false
+		);
 	}
 }
 
-/// Outputs styles for tooltip content.
-///
-/// @output The output includes all styles for tooltip content excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentBody($text-color: $_o-tooltip-text-color) {
-	@include oTypographySans();
-	color: $text-color;
-	position: relative;
-	box-sizing: border-box;
-	overflow: auto;
-	padding: 15px 35px 15px 20px;
-	float: left;
-	line-height: 1;
-	hyphens: auto; // Breaks long words to fit into smaller screen sizes
-
-	> *:first-child {
-		margin-top: 0;
-	}
-	> *:last-child {
-		margin-bottom: 0;
-	}
-}
-
-/// Outputs base styles for tooltip arrows.
-///
-/// @param {Number} size [10px] - The size of the arrow
-/// @output The output includes all styles for tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentArrow($size: 10px) {
-	// :before for the outer arrow that has the bordered colour,
-	// and :after for the inner arrow with the white background colour
-	&:before,
-	&:after {
-		content: "";
-		position: absolute;
-		border: solid transparent;
-	}
-	&:before {
-		// 1px offset so it appears properly
-		border-width: $size + $_o-tooltip-border-width + 1;
-	}
-	&:after {
-		border-width: $size;
-	}
-}
-
-/// Outputs base styles for top and bottom tooltip arrows.
-///
-/// @param {Number} size [10px] - The size of the arrow
-/// @output The output includes all styles for top and bottom tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentVerticalArrow($size: 10px) {
-	@include _oTooltipContentArrow;
-
-	&.o-tooltip-arrow--align-left:before,
-	&.o-tooltip-arrow--align-left:after {
-		left: 10%;
-	}
-
-	&.o-tooltip-arrow--align-right:before,
-	&.o-tooltip-arrow--align-right:after {
-		left: 90%;
-	}
-
-	&:before,
-	&:after {
-		left: 50%;
-	}
-	&:before {
-		// 1px offset so it appears properly
-		margin-left: -$size - $_o-tooltip-border-width - 1;
-	}
-	&:after {
-		margin-left: -$size;
-	}
-}
-
-/// Outputs base styles for top tooltip arrows.
-///
-/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
-/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
-/// @output The output includes all styles for top tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentUpArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
-	@include _oTooltipContentVerticalArrow;
-
-	&:before,
-	&:after {
-		bottom: 100%;
-		border-top-width: 0;
-	}
-	&:before {
-		border-bottom-color: $shadow-color;
-	}
-	&:after {
-		border-bottom-color: $color;
-	}
-}
-
-/// Outputs base styles for bottom tooltip arrows.
-///
-/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
-/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
-/// @output The output includes all styles for bottom tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentDownArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
-	@include _oTooltipContentVerticalArrow;
-
-	&:before,
-	&:after {
-		top: 100%;
-		border-bottom-width: 0;
-	}
-	&:before {
-		border-top-color: $shadow-color;
-	}
-	&:after {
-		border-top-color: $color;
-	}
-}
-
-/// Outputs base styles for left and right tooltip arrows.
-///
-/// @param {Number} size [10px] - The size of the arrow
-/// @output The output includes all styles for left and right tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentHorizontalArrow($size: 10px) {
-	@include _oTooltipContentArrow;
-
-	&.o-tooltip-arrow--align-top:before,
-	&.o-tooltip-arrow--align-top:after {
-		top: 0;
-		margin-top: 0;
-	}
-
-	&.o-tooltip-arrow--align-bottom:before,
-	&.o-tooltip-arrow--align-bottom:after {
-		top: auto;
-		bottom: 0;
-		margin-top: 0;
-	}
-
-
-	&:before,
-	&:after {
-		top: 50%;
-	}
-	&:before {
-		// 1px offset so it appears properly
-		margin-top: -$size - $_o-tooltip-border-width - 1;
-	}
-	&:after {
-		margin-top: -$size;
-	}
-}
-
-/// Outputs base styles for left tooltip arrows.
-///
-/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
-/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
-/// @output The output includes all styles for left tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentLeftArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
-	@include _oTooltipContentHorizontalArrow;
-
-	&:before,
-	&:after {
-		right: 100%;
-		border-left-width: 0;
-	}
-	&:before {
-		border-right-color: $shadow-color;
-	}
-	&:after {
-		border-right-color: $color;
-	}
-}
-
-/// Outputs base styles for right tooltip arrows.
-///
-/// @param {Color} color [$_o-tooltip-background-color] - The color of the arrow.
-/// @param {Color} shadow-color [$_o-tooltip-border-color] - The color of the arrow shadow.
-/// @output The output includes all styles for right tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentRightArrow($color: $_o-tooltip-background-color, $shadow-color: $_o-tooltip-border-color) {
-	@include _oTooltipContentHorizontalArrow;
-
-	&:before,
-	&:after {
-		left: 100%;
-		border-right-width: 0;
-	}
-	&:before {
-		border-left-color: $shadow-color;
-	}
-	&:after {
-		border-left-color: $color;
-	}
-}
-
-/// Outputs base styles for tooltip close buttons.
-///
-/// @param {Color} color [$_o-tooltip-text-color] - The color of the close icon.
-/// @output The output includes all styles for top tooltip arrows excluding a wrapping selector.
-/// @access private
-@mixin _oTooltipContentClose($color: $_o-tooltip-text-color) {
-	// TODO add support for passing color to close button
-	@include oOverlayContentClose; // ($color);
-	position: absolute;
-	top: 0;
-	right: 0;
-	padding: 0;
-	margin: 5px 5px 15px 15px;
-	border: 0;
-}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -50,11 +50,11 @@
 /// @access public
 @mixin _oTooltipThemeContent($theme: null) {
 	// Default theme values.
-	@if(type-of($theme) == 'map') {
-		$theme: map-merge((
-			'close-foreground-color': map-get($theme, 'foreground-color')
-		), $theme);
-	}
+	$close-foreground-color: if(
+		_oTooltipGet('close-foreground-color', $theme),
+		_oTooltipGet('close-foreground-color', $theme),
+		_oTooltipGet('foreground-color', $theme)
+	);
 
 	// Output theme CSS.
 	background: _oTooltipGet('background-color', $theme);
@@ -79,7 +79,7 @@
 	.o-tooltip-close {
 		@include oIconsContent(
 			'cross',
-			_oTooltipGet('foreground-color', $theme),
+			$close-foreground-color,
 			$size: 20px,
 			$include-base-styles: false
 		);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -20,14 +20,14 @@
 
 	@if type-of(map-get($opts, 'background-color')) != 'color' {
 		@error 'Could not add custom tooltip theme "#{$name}". Expected a ' +
-		'a "color" `background-colour` option. Found type ' +
-		'"#{type-of(map-get($opts, 'background-color'))}".';
+			'a "color" `background-colour` option. Found type ' +
+			'"#{type-of(map-get($opts, 'background-color'))}".';
 	}
 
 	@if type-of(map-get($opts, 'foreground-color')) != 'color' {
 		@error 'Could not add custom tooltip theme "#{$name}". Expected a ' +
-		'a "color" `foreground-colour` option. Found type ' +
-		'"#{type-of(map-get($opts, 'foreground-color'))}".';
+			'a "color" `foreground-colour` option. Found type ' +
+			'"#{type-of(map-get($opts, 'foreground-color'))}".';
 	}
 
 	.o-tooltip.o-tooltip--#{$name} {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -24,6 +24,12 @@ $_o-tooltip-animation-duration: 0.5s;
 /// @access private
 $_o-tooltip-background-color: oColorsByName('white');
 
+/// The text colour for tooltips.
+///
+/// @type {Color}
+/// @access private
+$_o-tooltip-text-color: oColorsByName('black');
+
 /// The border colour for tooltips.
 ///
 /// @type {Color}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -18,26 +18,18 @@ $_o-tooltip-animation-distance: 50px;
 /// @access private
 $_o-tooltip-animation-duration: 0.5s;
 
-/// The background colour for tooltips.
-///
-/// @type {Color}
-/// @access private
-$_o-tooltip-background-color: oColorsByName('white');
-
-/// The text colour for tooltips.
-///
-/// @type {Color}
-/// @access private
-$_o-tooltip-text-color: oColorsByName('black');
-
 /// The border colour for tooltips.
 ///
 /// @type {Color}
 /// @access private
-$_o-tooltip-border-color: rgba(0, 0, 0, 0.05);
+$_o-tooltip-shadow-color: rgba(0, 0, 0, 0.05);
 
 /// The border width for tooltips.
 ///
 /// @type {Number}
 /// @access private
 $_o-tooltip-border-width: 1px;
+
+/// @type {Number}
+/// @access private
+$_o-tooltip-arrow-size: 10px;


### PR DESCRIPTION
Update from @notlee:

Paired with @nickramsbottom on this yesterday. 🎉 

- Moves customisation options from the primary mixin to a new
mixin `oTooltipAddTheme`, so more that one tooltip style can
be used within a project without conflicts, and multiple styles
do not output all of o-tooltip CSS.
- Refactors to remove some private mixins. It was a little tricky
to jump around the mixins, and there were opportunities to combine
selectors to avoid repeated styles.

![Screenshot 2021-05-25 at 10 02 41](https://user-images.githubusercontent.com/10405691/119470565-6382b880-bd40-11eb-814d-320c054279e2.png)
